### PR TITLE
Day 2: UX, Insights, Preferences

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners for Trakkly
+# All changes require review from the listed owners when branch protection enforces CODEOWNERS reviews.
+
+* @jagged3dge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches: [ main, stage, dev, "feature/**" ]
   pull_request:
-    branches: [ main, stage, dev ]
+    branches: [ main ]
 
 jobs:
   app-lint-build:
@@ -31,3 +29,6 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Test
+        run: npm run test -- --run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,12 @@ We welcome contributions! Please follow these guidelines to keep the project mai
 - Keep commits small and atomic; use Conventional Commits (e.g., `feat:`, `fix:`, `docs:`)
 - Open PRs against `dev`. We promote to `stage` and `main` via release PRs.
 
+## Branch protection & permissions
+- Direct pushes/merges to long-lived branches are restricted to maintainers only (`main`, `stage`, `dev`).
+- External contributors must use Pull Requests targeting `dev`. Maintainers review and merge.
+- Protected branches require status checks (lint, build, tests) and CODEOWNERS review.
+- Emergency fixes may be pushed by maintainers directly with a follow-up PR documenting the change.
+
 ## Development
 - Requirements: Node 20+
 - Start dev server:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,10 @@ We welcome contributions! Please follow these guidelines to keep the project mai
 ## Branch protection & permissions
 - Direct pushes/merges to long-lived branches are restricted to maintainers only (`main`, `stage`, `dev`).
 - External contributors must use Pull Requests targeting `dev`. Maintainers review and merge.
-- Protected branches require status checks (lint, build, tests) and CODEOWNERS review.
+- Protected branches enforce:
+  - `main`: PR required, CODEOWNERS review, CI status checks required.
+  - `stage`: PR required, CODEOWNERS review, CI checks not required (fast promotion from `dev`).
+  - `dev`: Maintainers may push/merge directly (solo mode). PRs optional.
 - Emergency fixes may be pushed by maintainers directly with a follow-up PR documenting the change.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ In `app/`:
 - `npm run preview` — Preview production build
 - `npm run format` — Format source with Prettier
 - `npm run format:check` — Check formatting
+- `npm run test` — Run tests (Vitest)
+- `npm run test:watch` — Watch mode
+- `npm run test:coverage` — Coverage with v8
 
 ## Deployment (GitHub Pages)
 
@@ -45,6 +48,13 @@ Steps to enable:
 1. In GitHub repo Settings → Pages, set Source: GitHub Actions.
 2. Push to `stage` (staging URL) or `main` (prod URL) and wait for the Pages workflow to complete.
 3. The deployed URL will be printed in the Actions run summary (environment `github-pages`).
+
+## Branching & CI
+
+- Long-lived branches: `dev` (integration), `stage` (staging), `main` (production).
+- Work on `feature/<name>` branches off `dev`.
+- CI (lint/test/build) runs on pull requests targeting `main` only (stage → main promotions).
+- Maintainers may push directly to `dev` in solo mode; `stage` and `main` require PRs and CODEOWNERS review.
 
 ## Branching strategy
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -17,23 +17,38 @@
       "devDependencies": {
         "@eslint/js": "^9.35.0",
         "@tailwindcss/postcss": "^4.1.13",
+        "@testing-library/jest-dom": "^6.8.0",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.5.2",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.2",
+        "@vitest/coverage-v8": "^3.2.4",
         "autoprefixer": "^10.4.21",
         "eslint": "^9.35.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
+        "fake-indexeddb": "^6.2.2",
         "globals": "^16.4.0",
+        "jsdom": "^27.0.0",
+        "msw": "^2.11.3",
         "postcss": "^8.5.6",
         "prettier": "^3.3.3",
         "tailwindcss": "^4.1.13",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.43.0",
         "vite": "^7.1.6",
-        "vite-plugin-pwa": "^1.0.3"
+        "vite-plugin-pwa": "^1.0.3",
+        "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -47,6 +62,64 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.0.4.tgz",
+      "integrity": "sha512-cKjSKvWGmAziQWbCouOsFwb14mp1betm8Y7Fn+yglDMUUu3r9DCbJ9iJbeFDenLMqFbIMC0pQP8K+B8LAxX3OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.1.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
+      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.5.5.tgz",
+      "integrity": "sha512-kI2MX9pmImjxWT8nxDZY+MuN6r1jJGe7WxizEbsAEPB/zxfW5wYLIiPG1v3UKgEOOP8EsDkp0ZL99oRFAdPM8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -1604,6 +1677,174 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cookie": "^0.7.2"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "statuses": "^2.0.1"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
+      "integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.10",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
@@ -2252,6 +2493,197 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.0.tgz",
+      "integrity": "sha512-JWaTfCxI1eTmJ1BIv86vUfjVatOdxwD0DAVKYevY8SazeUUZtW+tNbsdejVO1GYE0GXJW1N1ahmiC3TFd+7wZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.18.tgz",
+      "integrity": "sha512-MilmWOzHa3Ks11tzvuAmFoAd/wRuaP3SwlT1IZhyMke31FKLxPiuDWcGXhU+PKveNOpAc4axzAgrgxuIJJRmLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.2.2.tgz",
+      "integrity": "sha512-yXq/4QUnk4sHMtmbd7irwiepjB8jXU0kkFRL4nr/aDBA2mDz13cMakEWdDwX3eSCTkk03kwcndD1zfRAIlELxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.0",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -2263,6 +2695,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2326,6 +2768,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.39.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.6.tgz",
+      "integrity": "sha512-bndDP83naYYkfayr/qhBHMhk0YGwS1iv6vaEGcr0SQbO0IZtbOPqjKjds/WcG+bJA+1T5vCx6kprKOzn5Bg+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2362,6 +2822,42 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3150,6 +3646,104 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
+      "integrity": "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3194,6 +3788,30 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3243,6 +3861,13 @@
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3545,6 +4170,195 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3568,6 +4382,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -3583,6 +4407,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -3607,6 +4441,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -3646,6 +4490,45 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.5.tgz",
+      "integrity": "sha512-9SdXjNheSiE8bALAQCQQuT6fgQaoxJh7IRYrRGZ8/9nv8WhJeC1aXAwN8TbaOssGOukUvyvnkgD9+Yuykvl1aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.30",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^9.0.1"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -3787,6 +4670,16 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3851,6 +4744,16 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -3933,6 +4836,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3950,6 +4870,16 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -3958,6 +4888,49 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/color-convert": {
@@ -4011,6 +4984,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie-es": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
@@ -4056,12 +5039,99 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.0.tgz",
+      "integrity": "sha512-RveJPnk3m7aarYQ2bJ6iw+Urh55S6FzUiqtBq+TihnTDP4cI8y/TYDqGOyqgnG1J1a6BxJXZsV9JFSTulm9Z7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.0.3",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.14",
+        "css-tree": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4135,6 +5205,23 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4188,6 +5275,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
@@ -4204,6 +5301,14 @@
       "integrity": "sha512-OSeyyWOUetDy9oFWeddJgi83OnRA3hSFh3RrbltmPgqHszE9f24eUCVLI4mPg0ifsWk0lQTdnS+jyGNrPMvhDA==",
       "license": "Apache-2.0"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4218,6 +5323,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -4242,6 +5354,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.18.3",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
@@ -4254,6 +5373,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -4344,6 +5476,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4642,6 +5781,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.2.tgz",
+      "integrity": "sha512-SGbf7fzjeHz3+12NO1dYigcYn4ivviaeULV5yY5rdGihBvvgwMds4r4UBbNIUMwkze57KTDm32rq3j1Az8mzEw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4833,6 +5992,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -4934,6 +6110,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -5092,6 +6278,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -5186,6 +6382,74 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
@@ -5228,6 +6492,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -5425,6 +6699,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
@@ -5490,6 +6774,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5526,6 +6817,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -5718,6 +7016,76 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jake": {
       "version": "10.9.4",
       "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
@@ -5764,6 +7132,83 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
+      "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.5.4",
+        "cssstyle": "^5.3.0",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.3.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0",
+        "ws": "^8.18.2",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/jsesc": {
@@ -6160,6 +7605,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6168,6 +7620,17 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -6180,6 +7643,47 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6189,6 +7693,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -6212,6 +7723,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -6272,6 +7793,75 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/msw": {
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.11.3.tgz",
+      "integrity": "sha512-878imp8jxIpfzuzxYfX0qqTq1IFQz/1/RBHs/PyirSjzi+xKM/RRfIpIqHSCWjH0GxidrjhgiiXC+DWXNDvT9w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.39.1",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.7.0",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.0",
+        "type-fest": "^4.26.1",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -6388,6 +7978,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -6438,6 +8035,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6449,6 +8053,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -6487,6 +8104,54 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6593,6 +8258,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6655,6 +8350,14 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -6663,6 +8366,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -6780,6 +8497,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -6820,6 +8547,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/rettime": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.7.0.tgz",
+      "integrity": "sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -6873,6 +8607,13 @@
         "@rollup/rollup-win32-x64-msvc": "4.52.0",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -6972,6 +8713,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -7169,6 +8930,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/smob": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
@@ -7229,6 +9010,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -7241,6 +9046,44 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -7345,6 +9188,33 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
@@ -7353,6 +9223,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -7367,6 +9250,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -7393,6 +9296,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.1.13",
@@ -7491,6 +9401,68 @@
         "node": ">=10"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -7501,6 +9473,20 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -7551,6 +9537,56 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.15.tgz",
+      "integrity": "sha512-heYRCiGLhtI+U/D0V8YM3QRwPfsLJiP+HX+YwiHZTnWzjIKC+ZCxQRYlzvOoTEc6KIP62B1VeAN63diGCng2hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.15"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.15.tgz",
+      "integrity": "sha512-YBkp2VfS9VTRMPNL2PA6PMESmxV1JEVoAr5iBlZnB5JG3KUrWzNCB3yNNkRa2FZkqClaBgfNYCp8PgpYmpjkZw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7562,6 +9598,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -7822,6 +9871,16 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
+    },
     "node_modules/upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -7958,6 +10017,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite-plugin-pwa": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-1.0.3.tgz",
@@ -8020,12 +10102,144 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "7.1.0",
@@ -8142,6 +10356,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -8502,6 +10733,40 @@
         "workbox-core": "7.3.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -8509,12 +10774,90 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -8524,6 +10867,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,10 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,md}\"",
-    "format:check": "prettier --check \"src/**/*.{ts,tsx,css,md}\""
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,css,md}\"",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@tanstack/react-router": "^1.131.49",
@@ -21,21 +24,29 @@
   "devDependencies": {
     "@eslint/js": "^9.35.0",
     "@tailwindcss/postcss": "^4.1.13",
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.5.2",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.2",
+    "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.35.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "fake-indexeddb": "^6.2.2",
     "globals": "^16.4.0",
+    "jsdom": "^27.0.0",
+    "msw": "^2.11.3",
     "postcss": "^8.5.6",
     "prettier": "^3.3.3",
     "tailwindcss": "^4.1.13",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.43.0",
     "vite": "^7.1.6",
-    "vite-plugin-pwa": "^1.0.3"
+    "vite-plugin-pwa": "^1.0.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/app/src/components/AddTrackerModal.test.tsx
+++ b/app/src/components/AddTrackerModal.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AddTrackerModal } from './AddTrackerModal'
+import { AdaptersProvider } from '../providers/AdaptersProvider'
+import { resetDb } from '../test/resetDb'
+import { db } from '../db/db'
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <AdaptersProvider>{children}</AdaptersProvider>
+}
+
+describe('AddTrackerModal', () => {
+  beforeEach(async () => {
+    await resetDb()
+  })
+
+  it('creates a tracker when valid name is provided', async () => {
+    const onClose = vi.fn()
+    render(
+      <Wrapper>
+        <AddTrackerModal open={true} onClose={onClose} />
+      </Wrapper>,
+    )
+
+    const name = screen.getByLabelText(/name/i)
+    await userEvent.type(name, 'Hydrate')
+
+    const save = screen.getByRole('button', { name: /save/i })
+    await userEvent.click(save)
+
+    // DB should contain the tracker
+    const trackers = await db.trackers.where('name').equals('Hydrate').toArray()
+    expect(trackers.length).toBe(1)
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('prevents save when name is empty', async () => {
+    const onClose = vi.fn()
+    render(
+      <Wrapper>
+        <AddTrackerModal open={true} onClose={onClose} />
+      </Wrapper>,
+    )
+
+    const save = screen.getByRole('button', { name: /save/i })
+    expect(save).toBeDisabled()
+  })
+})

--- a/app/src/components/AddTrackerModal.tsx
+++ b/app/src/components/AddTrackerModal.tsx
@@ -49,8 +49,9 @@ export function AddTrackerModal({ open, onClose }: { open: boolean; onClose: () 
     <Modal open={open} onClose={onClose} title="Add Tracker">
       <div className="space-y-3">
         <div>
-          <label className="block text-sm mb-1">Name</label>
+          <label htmlFor="tracker-name" className="block text-sm mb-1">Name</label>
           <input
+            id="tracker-name"
             value={name}
             onChange={(e) => setName(e.target.value)}
             className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-indigo-500 dark:border-neutral-700 dark:bg-neutral-900"
@@ -59,19 +60,21 @@ export function AddTrackerModal({ open, onClose }: { open: boolean; onClose: () 
         </div>
         <div className="flex gap-3">
           <div className="flex-1">
-            <label className="block text-sm mb-1">Step size</label>
+            <label htmlFor="tracker-step" className="block text-sm mb-1">Step size</label>
             <input
               type="number"
               min={1}
+              id="tracker-step"
               value={stepSize}
               onChange={(e) => setStepSize(parseInt(e.target.value || '1', 10))}
               className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-indigo-500 dark:border-neutral-700 dark:bg-neutral-900"
             />
           </div>
           <div className="flex-1">
-            <label className="block text-sm mb-1">Color</label>
+            <label htmlFor="tracker-color" className="block text-sm mb-1">Color</label>
             <input
               type="color"
+              id="tracker-color"
               value={color}
               onChange={(e) => setColor(e.target.value)}
               className="h-10 w-full rounded-lg border border-neutral-300 bg-white p-1 dark:border-neutral-700 dark:bg-neutral-900"
@@ -79,8 +82,9 @@ export function AddTrackerModal({ open, onClose }: { open: boolean; onClose: () 
           </div>
         </div>
         <div>
-          <label className="block text-sm mb-1">Icon (name)</label>
+          <label htmlFor="tracker-icon" className="block text-sm mb-1">Icon</label>
           <input
+            id="tracker-icon"
             value={icon}
             onChange={(e) => setIcon(e.target.value)}
             className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-indigo-500 dark:border-neutral-700 dark:bg-neutral-900"
@@ -88,8 +92,9 @@ export function AddTrackerModal({ open, onClose }: { open: boolean; onClose: () 
           />
         </div>
         <div>
-          <label className="block text-sm mb-1">Tags (comma separated)</label>
+          <label htmlFor="tracker-tags" className="block text-sm mb-1">Tags (comma separated)</label>
           <input
+            id="tracker-tags"
             value={tags}
             onChange={(e) => setTags(e.target.value)}
             className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-indigo-500 dark:border-neutral-700 dark:bg-neutral-900"
@@ -97,7 +102,7 @@ export function AddTrackerModal({ open, onClose }: { open: boolean; onClose: () 
           />
         </div>
         <label className="inline-flex items-center gap-2">
-          <input type="checkbox" checked={pinned} onChange={(e) => setPinned(e.target.checked)} />
+          <input aria-label="Pin to top" type="checkbox" checked={pinned} onChange={(e) => setPinned(e.target.checked)} />
           <span className="text-sm">Pin to top</span>
         </label>
 

--- a/app/src/components/TrackerList.test.tsx
+++ b/app/src/components/TrackerList.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TrackerList } from './TrackerList'
+import { AdaptersProvider } from '../providers/AdaptersProvider'
+import { resetDb } from '../test/resetDb'
+import { useTrakkly } from '../state/store'
+import { db } from '../db/db'
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <AdaptersProvider>{children}</AdaptersProvider>
+}
+
+async function createTracker(name: string, tags: string[] = []) {
+  return await useTrakkly.getState().createTracker({
+    name,
+    color: '#4f46e5',
+    icon: 'hash',
+    tags,
+    stepSize: 1,
+    pinned: false,
+  })
+}
+
+describe('TrackerList', () => {
+  beforeEach(async () => {
+    await resetDb()
+    useTrakkly.setState({ trackers: [], loading: false })
+  })
+
+  it('pin toggle updates button label and persists', async () => {
+    const t = await createTracker('Hydrate')
+    render(
+      <Wrapper>
+        <TrackerList />
+      </Wrapper>,
+    )
+
+    // Wait for tracker to appear
+    const item = await screen.findByText('Hydrate')
+    const card = item.closest('li') as HTMLElement
+    const pinBtn = within(card).getByRole('button', { name: /pin tracker/i })
+    await userEvent.click(pinBtn)
+
+    // Button should now be Unpin (wait for state update)
+    await within(card).findByRole('button', { name: /unpin tracker/i })
+
+    // Persisted
+    const persisted = await db.trackers.get(t.id)
+    expect(persisted?.pinned).toBe(true)
+  })
+
+  it('tag filter shows only trackers with selected tag', async () => {
+    await createTracker('Hydrate', ['health'])
+    await createTracker('Push Ups', ['gym'])
+    render(
+      <Wrapper>
+        <TrackerList />
+      </Wrapper>,
+    )
+
+    // Select tag "gym"
+    const select = await screen.findByLabelText(/tag/i)
+    await userEvent.selectOptions(select, 'gym')
+
+    expect(screen.queryByText('Hydrate')).not.toBeInTheDocument()
+    expect(screen.getByText('Push Ups')).toBeInTheDocument()
+  })
+})

--- a/app/src/components/TrackerList.tsx
+++ b/app/src/components/TrackerList.tsx
@@ -11,6 +11,7 @@ export function TrackerList() {
   const [adjustId, setAdjustId] = useState<string | null>(null)
   const [openHistory, setOpenHistory] = useState<Record<string, boolean>>({})
   const [showPinnedOnly, setShowPinnedOnly] = useState(false)
+  const [selectedTag, setSelectedTag] = useState<string>('')
 
   useEffect(() => {
     init()
@@ -56,15 +57,34 @@ export function TrackerList() {
         <p className="text-sm text-neutral-500 dark:text-neutral-400">No trackers yet.</p>
       ) : (
         <>
-          <div className="flex items-center justify-end">
-            <label className="inline-flex items-center gap-2 text-xs">
-              <input
-                type="checkbox"
-                checked={showPinnedOnly}
-                onChange={(e) => setShowPinnedOnly(e.target.checked)}
-              />
-              <span>Show pinned only</span>
-            </label>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="text-xs text-neutral-500">
+              {trackers.length} tracker{trackers.length !== 1 ? 's' : ''}
+            </div>
+            <div className="flex items-center gap-3">
+              <label className="inline-flex items-center gap-2 text-xs">
+                <input
+                  type="checkbox"
+                  checked={showPinnedOnly}
+                  onChange={(e) => setShowPinnedOnly(e.target.checked)}
+                />
+                <span>Show pinned only</span>
+              </label>
+              <div className="inline-flex items-center gap-2 text-xs">
+                <label htmlFor="tag-filter" className="text-neutral-600 dark:text-neutral-300">Tag</label>
+                <select
+                  id="tag-filter"
+                  className="rounded-md border border-neutral-300 bg-white px-2 py-1 dark:border-neutral-700 dark:bg-neutral-900"
+                  value={selectedTag}
+                  onChange={(e) => setSelectedTag(e.target.value)}
+                >
+                  <option value="">All</option>
+                  {Array.from(new Set(trackers.flatMap((t) => t.tags))).sort((a, b) => a.localeCompare(b)).map((tag) => (
+                    <option key={tag} value={tag}>{tag}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
           </div>
           <ul className="mt-2 grid grid-cols-1 gap-3">
             {trackers
@@ -76,6 +96,7 @@ export function TrackerList() {
                 return a.name.localeCompare(b.name)
               })
               .filter((t) => (showPinnedOnly ? t.pinned : true))
+              .filter((t) => (selectedTag ? t.tags.includes(selectedTag) : true))
               .map((t) => (
             <li key={t.id} className="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
               <div className="flex items-center justify-between">

--- a/app/src/components/TrackerList.tsx
+++ b/app/src/components/TrackerList.tsx
@@ -5,11 +5,12 @@ import { AdjustModal } from './AdjustModal'
 import { EventList } from './EventList'
 
 export function TrackerList() {
-  const { trackers, init, createTracker, increment } = useTrakkly()
+  const { trackers, init, createTracker, increment, togglePin } = useTrakkly()
   const [creating, setCreating] = useState(false)
   const [showAdd, setShowAdd] = useState(false)
   const [adjustId, setAdjustId] = useState<string | null>(null)
   const [openHistory, setOpenHistory] = useState<Record<string, boolean>>({})
+  const [showPinnedOnly, setShowPinnedOnly] = useState(false)
 
   useEffect(() => {
     init()
@@ -54,20 +55,51 @@ export function TrackerList() {
       {trackers.length === 0 ? (
         <p className="text-sm text-neutral-500 dark:text-neutral-400">No trackers yet.</p>
       ) : (
-        <ul className="grid grid-cols-1 gap-3">
-          {trackers.map((t) => (
+        <>
+          <div className="flex items-center justify-end">
+            <label className="inline-flex items-center gap-2 text-xs">
+              <input
+                type="checkbox"
+                checked={showPinnedOnly}
+                onChange={(e) => setShowPinnedOnly(e.target.checked)}
+              />
+              <span>Show pinned only</span>
+            </label>
+          </div>
+          <ul className="mt-2 grid grid-cols-1 gap-3">
+            {trackers
+              .slice()
+              .sort((a, b) => {
+                // pinned first, then updatedAt desc, then name
+                if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
+                if (a.updatedAt !== b.updatedAt) return a.updatedAt < b.updatedAt ? 1 : -1
+                return a.name.localeCompare(b.name)
+              })
+              .filter((t) => (showPinnedOnly ? t.pinned : true))
+              .map((t) => (
             <li key={t.id} className="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
               <div className="flex items-center justify-between">
                 <div>
                   <div className="font-medium">{t.name}</div>
                   <div className="text-xs text-neutral-500">step {t.stepSize}</div>
                 </div>
-                <button
-                  onClick={() => increment(t.id)}
-                  className="inline-flex items-center justify-center rounded-full bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700"
-                >
-                  +{t.stepSize}
-                </button>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => togglePin(t.id)}
+                    className="rounded-lg border border-neutral-300 px-3 py-1 text-xs hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+                    aria-pressed={t.pinned}
+                    aria-label={t.pinned ? 'Unpin tracker' : 'Pin tracker'}
+                    title={t.pinned ? 'Unpin' : 'Pin'}
+                  >
+                    {t.pinned ? 'Unpin' : 'Pin'}
+                  </button>
+                  <button
+                    onClick={() => increment(t.id)}
+                    className="inline-flex items-center justify-center rounded-full bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700"
+                  >
+                    +{t.stepSize}
+                  </button>
+                </div>
               </div>
               <div className="mt-2 flex items-center justify-between">
                 <button
@@ -90,7 +122,8 @@ export function TrackerList() {
               )}
             </li>
           ))}
-        </ul>
+          </ul>
+        </>
       )}
       <AddTrackerModal open={showAdd} onClose={() => setShowAdd(false)} />
       {adjustId && (

--- a/app/src/db/schema.ts
+++ b/app/src/db/schema.ts
@@ -38,4 +38,5 @@ export type UserPreferences = {
   locale?: string;
   clockFormat: ClockFormat;
   a11yPrefs?: AccessibilityPrefs;
+  telemetryEnabled?: boolean;
 };

--- a/app/src/lib/insights.test.ts
+++ b/app/src/lib/insights.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { eventsForThisWeek, eventsForToday, sumValue, totalsByDayInWeek, totalsByTracker } from './insights'
+import type { Event } from '../db/schema'
+
+function iso(year: number, monthIndex: number, day: number, h = 0, m = 0, s = 0) {
+  return new Date(year, monthIndex, day, h, m, s).toISOString()
+}
+
+describe('insights utilities', () => {
+  const now = new Date(2025, 8, 18) // 2025-09-18 (Thu)
+  const events: Event[] = [
+    { id: 'e1', trackerId: 't1', type: 'increment', value: 1, createdAt: iso(2025, 8, 18, 9), deviceId: 'd' }, // Thu
+    { id: 'e2', trackerId: 't1', type: 'increment', value: 2, createdAt: iso(2025, 8, 18, 10), deviceId: 'd' }, // Thu
+    { id: 'e3', trackerId: 't2', type: 'adjustment', value: -1, createdAt: iso(2025, 8, 17), deviceId: 'd' }, // Wed
+    { id: 'e4', trackerId: 't2', type: 'increment', value: 3, createdAt: iso(2025, 8, 15), deviceId: 'd' }, // Mon
+    { id: 'e5', trackerId: 't1', type: 'increment', value: 5, createdAt: iso(2025, 8, 22), deviceId: 'd' }, // Mon next week
+  ]
+
+  it('eventsForToday returns only events from today', () => {
+    const today = eventsForToday(events, now)
+    expect(today.map((e) => e.id)).toEqual(['e1', 'e2'])
+  })
+
+  it('eventsForThisWeek returns events within same ISO week', () => {
+    const week = eventsForThisWeek(events, now)
+    // Should include Mon(15), Wed(17), Thu(18) but not next Monday(22)
+    expect(week.map((e) => e.id).sort()).toEqual(['e1', 'e2', 'e3', 'e4'].sort())
+  })
+
+  it('totalsByTracker sums values per tracker', () => {
+    const week = eventsForThisWeek(events, now)
+    const map = totalsByTracker(week)
+    expect(map.get('t1')).toBe(1 + 2)
+    expect(map.get('t2')).toBe(-1 + 3)
+  })
+
+  it('sumValue sums event values', () => {
+    const week = eventsForThisWeek(events, now)
+    expect(sumValue(week)).toBe(1 + 2 + (-1) + 3)
+  })
+
+  it('totalsByDayInWeek produces 7 bins starting Monday', () => {
+    const days = totalsByDayInWeek(events, now)
+    expect(days).toHaveLength(7)
+    // Mon index 0, Wed index 2, Thu index 3 (relative to Monday start)
+    expect(days[0].total).toBe(3) // e4
+    expect(days[2].total).toBe(-1) // e3
+    expect(days[3].total).toBe(1 + 2) // e1 + e2
+    // Next Monday (e5) should not be included
+    expect(days[6].total).toBe(0)
+  })
+})

--- a/app/src/lib/insights.ts
+++ b/app/src/lib/insights.ts
@@ -1,0 +1,53 @@
+import type { Event } from '../db/schema'
+import { isSameDay, startOfWeek } from './time'
+
+function toDate(iso: string): Date {
+  return new Date(iso)
+}
+
+export function eventsForToday(events: Event[], now = new Date()): Event[] {
+  return events.filter((e) => isSameDay(toDate(e.createdAt), now))
+}
+
+export function isSameWeekLocal(a: Date, b: Date): boolean {
+  const sa = startOfWeek(a)
+  const sb = startOfWeek(b)
+  return isSameDay(sa, sb)
+}
+
+export function eventsForThisWeek(events: Event[], now = new Date()): Event[] {
+  return events.filter((e) => isSameWeekLocal(toDate(e.createdAt), now))
+}
+
+export function sumValue(events: Event[]): number {
+  return events.reduce((acc, e) => acc + (e.value || 0), 0)
+}
+
+export function totalsByTracker(events: Event[]): Map<string, number> {
+  const m = new Map<string, number>()
+  for (const e of events) {
+    m.set(e.trackerId, (m.get(e.trackerId) || 0) + (e.value || 0))
+  }
+  return m
+}
+
+export type DayTotal = { date: Date; total: number }
+
+export function totalsByDayInWeek(events: Event[], now = new Date()): DayTotal[] {
+  const start = startOfWeek(now)
+  const days: DayTotal[] = Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(start)
+    d.setDate(start.getDate() + i)
+    d.setHours(0, 0, 0, 0)
+    return { date: d, total: 0 }
+  })
+
+  for (const e of eventsForThisWeek(events, now)) {
+    const d = toDate(e.createdAt)
+    const dayIndex = Math.floor((d.getTime() - start.getTime()) / (24 * 60 * 60 * 1000))
+    if (dayIndex >= 0 && dayIndex < 7) {
+      days[dayIndex].total += e.value || 0
+    }
+  }
+  return days
+}

--- a/app/src/lib/insights.ts
+++ b/app/src/lib/insights.ts
@@ -85,3 +85,27 @@ export function sparklinePath(bins: number[], width = 160, height = 28, padding 
   const [x0, y0] = points[0]
   return 'M ' + x0 + ' ' + y0 + points.slice(1).map(([x, y]) => ` L ${x} ${y}`).join('')
 }
+
+// --- Daily bars over a sliding window ---
+
+export function totalsByLastNDays(events: Event[], n: number, now = new Date()): DayTotal[] {
+  const end = new Date(now)
+  end.setHours(0, 0, 0, 0)
+  const start = new Date(end)
+  start.setDate(end.getDate() - (n - 1))
+  const days: DayTotal[] = Array.from({ length: n }, (_, i) => {
+    const d = new Date(start)
+    d.setDate(start.getDate() + i)
+    d.setHours(0, 0, 0, 0)
+    return { date: d, total: 0 }
+  })
+  for (const e of events) {
+    const d = toDate(e.createdAt)
+    const dd = new Date(d)
+    dd.setHours(0, 0, 0, 0)
+    if (dd < start || dd > end) continue
+    const idx = Math.floor((dd.getTime() - start.getTime()) / (24 * 60 * 60 * 1000))
+    if (idx >= 0 && idx < n) days[idx].total += e.value || 0
+  }
+  return days
+}

--- a/app/src/lib/time.test.ts
+++ b/app/src/lib/time.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { startOfDay, isSameDay, startOfWeek, isSameWeek } from './time'
+
+describe('time utils', () => {
+  it('startOfDay normalizes to midnight', () => {
+    const d = new Date(2025, 8, 20, 15, 34, 0) // local time: Sep 20, 2025 15:34
+    const s = startOfDay(d)
+    expect(s.getHours()).toBe(0)
+    expect(s.getMinutes()).toBe(0)
+  })
+
+  it('isSameDay detects same calendar day', () => {
+    const a = new Date(2025, 8, 20, 1, 0, 0)
+    const b = new Date(2025, 8, 20, 23, 59, 59)
+    expect(isSameDay(a, b)).toBe(true)
+  })
+
+  it('startOfWeek returns Monday start', () => {
+    const wed = new Date(2025, 8, 17, 10, 0, 0) // local Wednesday
+    const wstart = startOfWeek(wed)
+    // Monday of that ISO week is 2025-09-15 (local)
+    expect(wstart.getDate()).toBe(15)
+  })
+
+  it('isSameWeek compares ISO weeks (Mon-Sun)', () => {
+    const a = new Date(2025, 8, 15, 0, 0, 0) // local Monday
+    const b = new Date(2025, 8, 21, 23, 59, 59) // local Sunday same week
+    expect(isSameWeek(a, b)).toBe(true)
+  })
+})

--- a/app/src/lib/time.ts
+++ b/app/src/lib/time.ts
@@ -1,0 +1,28 @@
+export function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate())
+}
+
+export function toISODate(d: Date): string {
+  const sd = startOfDay(d)
+  return sd.toISOString()
+}
+
+export function isSameDay(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()
+}
+
+export function startOfWeek(d: Date): Date {
+  // Week starts on Monday
+  const day = d.getDay() || 7 // 1..7 (Mon..Sun)
+  const diff = day - 1
+  const res = new Date(d)
+  res.setHours(0, 0, 0, 0)
+  res.setDate(res.getDate() - diff)
+  return res
+}
+
+export function isSameWeek(a: Date, b: Date): boolean {
+  const sa = startOfWeek(a)
+  const sb = startOfWeek(b)
+  return isSameDay(sa, sb)
+}

--- a/app/src/pages/Insights.tsx
+++ b/app/src/pages/Insights.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { db } from '../db/db'
 import type { Event, Tracker } from '../db/schema'
-import { eventsForThisWeek, eventsForToday, sumValue, totalsByDayInWeek, totalsByTracker, binsForToday, sparklinePath } from '../lib/insights'
+import { eventsForThisWeek, eventsForToday, sumValue, totalsByDayInWeek, totalsByTracker, binsForToday, sparklinePath, totalsByLastNDays } from '../lib/insights'
 
 export default function Insights() {
   const [events, setEvents] = useState<Event[]>([])
@@ -31,6 +31,7 @@ export default function Insights() {
   const weekDays = useMemo(() => totalsByDayInWeek(events, now), [events, now])
   const todayBins = useMemo(() => binsForToday(events, now), [events, now])
   const todayPath = useMemo(() => sparklinePath(todayBins), [todayBins])
+  const last7 = useMemo(() => totalsByLastNDays(events, 7, now), [events, now])
 
   if (loading) return <div className="text-sm text-neutral-500">Loading…</div>
 
@@ -68,6 +69,28 @@ export default function Insights() {
                 <div className="text-[10px] text-neutral-500">{days[i]}</div>
               </div>
             ))
+          })()}
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+        <div className="mb-2 font-medium">Last 7 days</div>
+        <div className="flex items-end gap-2" aria-label="Last 7 days totals bar chart">
+          {(() => {
+            const max = Math.max(1, ...last7.map((d) => d.total))
+            return last7.map((d, i) => {
+              const label = d.date.toLocaleDateString(undefined, { weekday: 'short' })
+              return (
+                <div key={i} className="flex w-8 flex-col items-center gap-1">
+                  <div
+                    className="w-full rounded-md bg-indigo-600"
+                    style={{ height: `${(d.total / max) * 64}px` }}
+                    title={`${label}: ${d.total}`}
+                  />
+                  <div className="text-[10px] text-neutral-500">{label}</div>
+                </div>
+              )
+            })
           })()}
         </div>
       </div>

--- a/app/src/pages/Insights.tsx
+++ b/app/src/pages/Insights.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useMemo, useState } from 'react'
+import { db } from '../db/db'
+import type { Event, Tracker } from '../db/schema'
+import { isSameDay, isSameWeek } from '../lib/time'
+
+export default function Insights() {
+  const [events, setEvents] = useState<Event[]>([])
+  const [trackers, setTrackers] = useState<Tracker[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true)
+      const [ev, tr] = await Promise.all([db.events.toArray(), db.trackers.toArray()])
+      // sort newest first
+      ev.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+      setEvents(ev)
+      setTrackers(tr)
+      setLoading(false)
+    }
+    load()
+  }, [])
+
+  const now = new Date()
+  const today = useMemo(() => events.filter((e) => isSameDay(new Date(e.createdAt), now)), [events, now])
+  const thisWeek = useMemo(
+    () => events.filter((e) => isSameWeek(new Date(e.createdAt), now)),
+    [events, now],
+  )
+
+  function sum(vals: number[]) {
+    return vals.reduce((a, b) => a + b, 0)
+  }
+
+  const todayCount = sum(today.map((e) => e.value))
+  const weekCount = sum(thisWeek.map((e) => e.value))
+
+  const perTrackerToday = useMemo(() => {
+    const map = new Map<string, number>()
+    today.forEach((e) => map.set(e.trackerId, (map.get(e.trackerId) || 0) + e.value))
+    return map
+  }, [today])
+
+  const perTrackerWeek = useMemo(() => {
+    const map = new Map<string, number>()
+    thisWeek.forEach((e) => map.set(e.trackerId, (map.get(e.trackerId) || 0) + e.value))
+    return map
+  }, [thisWeek])
+
+  if (loading) return <div className="text-sm text-neutral-500">Loading…</div>
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+          <div className="text-xs text-neutral-500">Today</div>
+          <div className="mt-1 text-2xl font-semibold">{todayCount}</div>
+        </div>
+        <div className="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+          <div className="text-xs text-neutral-500">This week</div>
+          <div className="mt-1 text-2xl font-semibold">{weekCount}</div>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+        <div className="mb-2 font-medium">By tracker — today</div>
+        {trackers.length === 0 ? (
+          <div className="text-sm text-neutral-500">No trackers yet.</div>
+        ) : (
+          <ul className="space-y-1">
+            {trackers.map((t) => (
+              <li key={t.id} className="flex items-center justify-between text-sm">
+                <span>{t.name}</span>
+                <span className="font-mono">{perTrackerToday.get(t.id) || 0}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+        <div className="mb-2 font-medium">By tracker — this week</div>
+        {trackers.length === 0 ? (
+          <div className="text-sm text-neutral-500">No trackers yet.</div>
+        ) : (
+          <ul className="space-y-1">
+            {trackers.map((t) => (
+              <li key={t.id} className="flex items-center justify-between text-sm">
+                <span>{t.name}</span>
+                <span className="font-mono">{perTrackerWeek.get(t.id) || 0}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/src/pages/Insights.tsx
+++ b/app/src/pages/Insights.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { db } from '../db/db'
 import type { Event, Tracker } from '../db/schema'
-import { eventsForThisWeek, eventsForToday, sumValue, totalsByDayInWeek, totalsByTracker } from '../lib/insights'
+import { eventsForThisWeek, eventsForToday, sumValue, totalsByDayInWeek, totalsByTracker, binsForToday, sparklinePath } from '../lib/insights'
 
 export default function Insights() {
   const [events, setEvents] = useState<Event[]>([])
@@ -29,6 +29,8 @@ export default function Insights() {
   const perTrackerToday = useMemo(() => totalsByTracker(today), [today])
   const perTrackerWeek = useMemo(() => totalsByTracker(thisWeek), [thisWeek])
   const weekDays = useMemo(() => totalsByDayInWeek(events, now), [events, now])
+  const todayBins = useMemo(() => binsForToday(events, now), [events, now])
+  const todayPath = useMemo(() => sparklinePath(todayBins), [todayBins])
 
   if (loading) return <div className="text-sm text-neutral-500">Loading…</div>
 
@@ -37,7 +39,12 @@ export default function Insights() {
       <div className="grid grid-cols-2 gap-3">
         <div className="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
           <div className="text-xs text-neutral-500">Today</div>
-          <div className="mt-1 text-2xl font-semibold">{todayCount}</div>
+          <div className="mt-1 flex items-end justify-between gap-3">
+            <div className="text-2xl font-semibold">{todayCount}</div>
+            <svg width="160" height="28" viewBox="0 0 160 28" role="img" aria-label="Today sparkline">
+              <path d={todayPath} fill="none" stroke="currentColor" strokeWidth="2" className="text-indigo-600" />
+            </svg>
+          </div>
         </div>
         <div className="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
           <div className="text-xs text-neutral-500">This week</div>

--- a/app/src/pages/Preferences.tsx
+++ b/app/src/pages/Preferences.tsx
@@ -1,0 +1,86 @@
+import { useEffect } from 'react'
+import { usePrefs } from '../state/prefs'
+
+export default function Preferences() {
+  const { prefs, loaded, load, setTimezone, setLocale, setClockFormat, setReducedMotion, setHighContrast } = usePrefs()
+
+  useEffect(() => {
+    if (!loaded) void load()
+  }, [loaded, load])
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+        <div className="mb-2 font-medium">Region</div>
+        <div className="space-y-3">
+          <div>
+            <label htmlFor="pref-locale" className="block text-sm mb-1">Locale (e.g. en-US)</label>
+            <input
+              id="pref-locale"
+              value={prefs.locale || ''}
+              onChange={(e) => setLocale(e.target.value || undefined)}
+              placeholder="System default"
+              className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-indigo-500 dark:border-neutral-700 dark:bg-neutral-900"
+            />
+          </div>
+          <div>
+            <label htmlFor="pref-timezone" className="block text-sm mb-1">Timezone (IANA, e.g. Asia/Kolkata)</label>
+            <input
+              id="pref-timezone"
+              value={prefs.timezone || ''}
+              onChange={(e) => setTimezone(e.target.value || undefined)}
+              placeholder="System default"
+              className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-indigo-500 dark:border-neutral-700 dark:bg-neutral-900"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+        <div className="mb-2 font-medium">Clock</div>
+        <div className="flex gap-4 text-sm">
+          <label className="inline-flex items-center gap-2">
+            <input
+              type="radio"
+              name="clock-format"
+              checked={prefs.clockFormat === '12'}
+              onChange={() => setClockFormat('12')}
+            />
+            12-hour
+          </label>
+          <label className="inline-flex items-center gap-2">
+            <input
+              type="radio"
+              name="clock-format"
+              checked={prefs.clockFormat === '24'}
+              onChange={() => setClockFormat('24')}
+            />
+            24-hour
+          </label>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+        <div className="mb-2 font-medium">Accessibility</div>
+        <div className="flex flex-col gap-2 text-sm">
+          <label className="inline-flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={!!prefs.a11yPrefs?.reducedMotion}
+              onChange={(e) => setReducedMotion(e.target.checked)}
+            />
+            Reduced motion
+          </label>
+          <label className="inline-flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={!!prefs.a11yPrefs?.highContrast}
+              onChange={(e) => setHighContrast(e.target.checked)}
+            />
+            High contrast
+          </label>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/pages/Preferences.tsx
+++ b/app/src/pages/Preferences.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { usePrefs } from '../state/prefs'
 
 export default function Preferences() {
-  const { prefs, loaded, load, setTimezone, setLocale, setClockFormat, setReducedMotion, setHighContrast } = usePrefs()
+  const { prefs, loaded, load, setTimezone, setLocale, setClockFormat, setReducedMotion, setHighContrast, setTelemetryEnabled } = usePrefs()
 
   useEffect(() => {
     if (!loaded) void load()
@@ -80,6 +80,21 @@ export default function Preferences() {
             High contrast
           </label>
         </div>
+      </div>
+
+      <div className="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+        <div className="mb-2 font-medium">Privacy</div>
+        <div className="text-sm text-neutral-600 dark:text-neutral-300 mb-2">
+          Telemetry is opt-in. When enabled, crash and product analytics may be collected (if keys are configured). No sensitive data is sent.
+        </div>
+        <label className="inline-flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={!!prefs.telemetryEnabled}
+            onChange={(e) => setTelemetryEnabled(e.target.checked)}
+          />
+          Enable telemetry
+        </label>
       </div>
     </div>
   )

--- a/app/src/providers/AdaptersProvider.tsx
+++ b/app/src/providers/AdaptersProvider.tsx
@@ -1,9 +1,10 @@
-import React, { createContext, useContext, useMemo } from 'react';
+import React, { createContext, useContext, useEffect, useMemo } from 'react';
 import { loadEnv, type EnvConfig } from '../config/env';
 import { NoopTelemetryAdapter, type TelemetryAdapter } from '../adapters/telemetry';
 import { LocalOnlySyncAdapter, type SyncAdapter } from '../adapters/sync';
 import { PlaceholderCryptoEngine, type CryptoEngine } from '../adapters/crypto';
 import { NoopDeviceUnlockAdapter, type DeviceUnlockAdapter } from '../adapters/deviceUnlock';
+import { usePrefs } from '../state/prefs';
 
 export type Adapters = {
   env: EnvConfig;
@@ -17,9 +18,11 @@ const AdaptersContext = createContext<Adapters | null>(null);
 
 export function AdaptersProvider({ children }: { children: React.ReactNode }) {
   const env = useMemo(() => loadEnv(), []);
+  const { prefs, loaded, load } = usePrefs();
 
   const telemetry = useMemo(() => {
     const t = new NoopTelemetryAdapter();
+    // initial enable follows env; will be updated once prefs load
     t.setEnabled(!!env.telemetry.enabled);
     return t;
   }, [env]);
@@ -34,6 +37,17 @@ export function AdaptersProvider({ children }: { children: React.ReactNode }) {
   const deviceUnlock = useMemo(() => new NoopDeviceUnlockAdapter(), []);
 
   const value: Adapters = { env, telemetry, sync, crypto, deviceUnlock };
+
+  // Load preferences on app start to apply telemetry preference
+  useEffect(() => {
+    if (!loaded) void load();
+  }, [loaded, load]);
+
+  // Apply telemetryEnabled preference whenever it changes
+  useEffect(() => {
+    const shouldEnable = !!env.telemetry.enabled && !!prefs.telemetryEnabled;
+    telemetry.setEnabled(shouldEnable);
+  }, [env.telemetry.enabled, prefs.telemetryEnabled, telemetry]);
 
   return (
     <AdaptersContext.Provider value={value}>{children}</AdaptersContext.Provider>

--- a/app/src/router.tsx
+++ b/app/src/router.tsx
@@ -1,5 +1,6 @@
-import { Outlet, createRootRoute, createRoute, createRouter } from '@tanstack/react-router'
+import { Outlet, Link, createRootRoute, createRoute, createRouter } from '@tanstack/react-router'
 import { TrackerList } from './components/TrackerList'
+import Insights from './pages/Insights'
 
 // Root layout
 export const Root = () => (
@@ -7,6 +8,22 @@ export const Root = () => (
     <header className="sticky top-0 z-10 border-b bg-white/80 px-4 py-3 backdrop-blur dark:border-neutral-800 dark:bg-neutral-900/80">
       <h1 className="text-2xl font-semibold tracking-tight">Trakkly</h1>
       <p className="text-sm text-neutral-500 dark:text-neutral-400">Offline-first counters with privacy</p>
+      <nav className="mt-2 flex gap-2 text-sm">
+        <Link
+          to="/"
+          activeProps={{ className: 'bg-indigo-600 text-white' }}
+          className="rounded-lg border border-neutral-300 px-3 py-1 hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+        >
+          Trackers
+        </Link>
+        <Link
+          to="/insights"
+          activeProps={{ className: 'bg-indigo-600 text-white' }}
+          className="rounded-lg border border-neutral-300 px-3 py-1 hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+        >
+          Insights
+        </Link>
+      </nav>
     </header>
     <main className="p-4">
       <div className="mx-auto max-w-md">
@@ -34,7 +51,13 @@ const indexRoute = createRoute({
   component: TrackerList,
 })
 
-const routeTree = rootRoute.addChildren([indexRoute])
+const insightsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/insights',
+  component: Insights,
+})
+
+const routeTree = rootRoute.addChildren([indexRoute, insightsRoute])
 
 export const router = createRouter({
   routeTree,

--- a/app/src/router.tsx
+++ b/app/src/router.tsx
@@ -1,6 +1,7 @@
 import { Outlet, Link, createRootRoute, createRoute, createRouter } from '@tanstack/react-router'
 import { TrackerList } from './components/TrackerList'
 import Insights from './pages/Insights'
+import Preferences from './pages/Preferences'
 
 // Root layout
 export const Root = () => (
@@ -22,6 +23,13 @@ export const Root = () => (
           className="rounded-lg border border-neutral-300 px-3 py-1 hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
         >
           Insights
+        </Link>
+        <Link
+          to="/prefs"
+          activeProps={{ className: 'bg-indigo-600 text-white' }}
+          className="rounded-lg border border-neutral-300 px-3 py-1 hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+        >
+          Preferences
         </Link>
       </nav>
     </header>
@@ -57,7 +65,13 @@ const insightsRoute = createRoute({
   component: Insights,
 })
 
-const routeTree = rootRoute.addChildren([indexRoute, insightsRoute])
+const prefsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/prefs',
+  component: Preferences,
+})
+
+const routeTree = rootRoute.addChildren([indexRoute, insightsRoute, prefsRoute])
 
 export const router = createRouter({
   routeTree,

--- a/app/src/state/prefs.test.ts
+++ b/app/src/state/prefs.test.ts
@@ -62,4 +62,14 @@ describe('preferences store', () => {
     expect(persisted?.a11yPrefs?.reducedMotion).toBe(true)
     expect(persisted?.a11yPrefs?.highContrast).toBe(true)
   })
+
+  it('telemetryEnabled defaults to false and can be toggled', async () => {
+    await usePrefs.getState().load()
+    expect(usePrefs.getState().prefs.telemetryEnabled).toBe(false)
+
+    await usePrefs.getState().setTelemetryEnabled(true)
+    expect(usePrefs.getState().prefs.telemetryEnabled).toBe(true)
+    const persisted = await db.preferences.get('user')
+    expect(persisted?.telemetryEnabled).toBe(true)
+  })
 })

--- a/app/src/state/prefs.test.ts
+++ b/app/src/state/prefs.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { usePrefs } from './prefs'
+import { resetDb } from '../test/resetDb'
+import { db } from '../db/db'
+
+function resetStore() {
+  usePrefs.setState({
+    prefs: {
+      id: 'user',
+      timezone: undefined,
+      locale: undefined,
+      clockFormat: '24',
+      a11yPrefs: { reducedMotion: false, highContrast: false },
+    },
+    loading: false,
+    loaded: false,
+    load: usePrefs.getState().load,
+    setTimezone: usePrefs.getState().setTimezone,
+    setLocale: usePrefs.getState().setLocale,
+    setClockFormat: usePrefs.getState().setClockFormat,
+    setReducedMotion: usePrefs.getState().setReducedMotion,
+    setHighContrast: usePrefs.getState().setHighContrast,
+  })
+}
+
+describe('preferences store', () => {
+  beforeEach(async () => {
+    await resetDb()
+    resetStore()
+  })
+
+  it('load seeds defaults when none exist', async () => {
+    await usePrefs.getState().load()
+    const prefs = usePrefs.getState().prefs
+    expect(prefs.id).toBe('user')
+    expect(prefs.clockFormat).toBe('24')
+    const persisted = await db.preferences.get('user')
+    expect(persisted).toBeTruthy()
+    expect(persisted?.clockFormat).toBe('24')
+  })
+
+  it('setters persist to Dexie and update store state', async () => {
+    await usePrefs.getState().load()
+
+    await usePrefs.getState().setTimezone('Asia/Kolkata')
+    await usePrefs.getState().setLocale('en-IN')
+    await usePrefs.getState().setClockFormat('12')
+    await usePrefs.getState().setReducedMotion(true)
+    await usePrefs.getState().setHighContrast(true)
+
+    const s = usePrefs.getState().prefs
+    expect(s.timezone).toBe('Asia/Kolkata')
+    expect(s.locale).toBe('en-IN')
+    expect(s.clockFormat).toBe('12')
+    expect(s.a11yPrefs?.reducedMotion).toBe(true)
+    expect(s.a11yPrefs?.highContrast).toBe(true)
+
+    const persisted = await db.preferences.get('user')
+    expect(persisted?.timezone).toBe('Asia/Kolkata')
+    expect(persisted?.locale).toBe('en-IN')
+    expect(persisted?.clockFormat).toBe('12')
+    expect(persisted?.a11yPrefs?.reducedMotion).toBe(true)
+    expect(persisted?.a11yPrefs?.highContrast).toBe(true)
+  })
+})

--- a/app/src/state/prefs.ts
+++ b/app/src/state/prefs.ts
@@ -10,6 +10,7 @@ const defaultPrefs: UserPreferences = {
   locale: undefined,
   clockFormat: '24',
   a11yPrefs: { reducedMotion: false, highContrast: false },
+  telemetryEnabled: false,
 }
 
 export type PrefsState = {
@@ -22,6 +23,7 @@ export type PrefsState = {
   setClockFormat: (format: ClockFormat) => Promise<void>
   setReducedMotion: (value: boolean) => Promise<void>
   setHighContrast: (value: boolean) => Promise<void>
+  setTelemetryEnabled: (value: boolean) => Promise<void>
 }
 
 async function ensurePrefs(): Promise<UserPreferences> {
@@ -73,6 +75,13 @@ export const usePrefs = create<PrefsState>((set, get) => ({
   setHighContrast: async (value) => {
     const current = get().prefs
     const next = { ...current, a11yPrefs: { ...(current.a11yPrefs || {}), highContrast: value } }
+    await db.preferences.put(next)
+    set({ prefs: next })
+  },
+
+  setTelemetryEnabled: async (value) => {
+    const current = get().prefs
+    const next = { ...current, telemetryEnabled: value }
     await db.preferences.put(next)
     set({ prefs: next })
   },

--- a/app/src/state/prefs.ts
+++ b/app/src/state/prefs.ts
@@ -1,0 +1,79 @@
+import { create } from 'zustand'
+import { db } from '../db/db'
+import type { UserPreferences, ClockFormat } from '../db/schema'
+
+const PREFERENCES_ID = 'user'
+
+const defaultPrefs: UserPreferences = {
+  id: PREFERENCES_ID,
+  timezone: undefined,
+  locale: undefined,
+  clockFormat: '24',
+  a11yPrefs: { reducedMotion: false, highContrast: false },
+}
+
+export type PrefsState = {
+  prefs: UserPreferences
+  loading: boolean
+  loaded: boolean
+  load: () => Promise<void>
+  setTimezone: (tz?: string) => Promise<void>
+  setLocale: (locale?: string) => Promise<void>
+  setClockFormat: (format: ClockFormat) => Promise<void>
+  setReducedMotion: (value: boolean) => Promise<void>
+  setHighContrast: (value: boolean) => Promise<void>
+}
+
+async function ensurePrefs(): Promise<UserPreferences> {
+  const existing = await db.preferences.get(PREFERENCES_ID)
+  if (existing) return existing
+  await db.preferences.put(defaultPrefs)
+  return defaultPrefs
+}
+
+export const usePrefs = create<PrefsState>((set, get) => ({
+  prefs: defaultPrefs,
+  loading: false,
+  loaded: false,
+
+  load: async () => {
+    set({ loading: true })
+    const prefs = await ensurePrefs()
+    set({ prefs, loading: false, loaded: true })
+  },
+
+  setTimezone: async (tz) => {
+    const current = get().prefs
+    const next = { ...current, timezone: tz }
+    await db.preferences.put(next)
+    set({ prefs: next })
+  },
+
+  setLocale: async (locale) => {
+    const current = get().prefs
+    const next = { ...current, locale }
+    await db.preferences.put(next)
+    set({ prefs: next })
+  },
+
+  setClockFormat: async (format) => {
+    const current = get().prefs
+    const next = { ...current, clockFormat: format }
+    await db.preferences.put(next)
+    set({ prefs: next })
+  },
+
+  setReducedMotion: async (value) => {
+    const current = get().prefs
+    const next = { ...current, a11yPrefs: { ...(current.a11yPrefs || {}), reducedMotion: value } }
+    await db.preferences.put(next)
+    set({ prefs: next })
+  },
+
+  setHighContrast: async (value) => {
+    const current = get().prefs
+    const next = { ...current, a11yPrefs: { ...(current.a11yPrefs || {}), highContrast: value } }
+    await db.preferences.put(next)
+    set({ prefs: next })
+  },
+}))

--- a/app/src/state/store.test.ts
+++ b/app/src/state/store.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { db } from '../db/db'
+import { useTrakkly } from './store'
+import { resetDb } from '../test/resetDb'
+
+async function createSampleTracker() {
+  const t = await useTrakkly.getState().createTracker({
+    name: '  Water  ',
+    color: '#4f46e5',
+    icon: 'drop',
+    tags: ['health'],
+    // stepSize optional; defaults to 1
+    stepSize: 1,
+    pinned: false,
+  })
+  return t
+}
+
+describe('store actions', () => {
+  beforeEach(async () => {
+    await resetDb()
+    useTrakkly.setState({ trackers: [], loading: false })
+  })
+
+  it('createTracker trims name, sets defaults, and persists', async () => {
+    const tracker = await createSampleTracker()
+    const persisted = await db.trackers.get(tracker.id)
+    expect(persisted).toBeTruthy()
+    expect(persisted!.name).toBe('Water')
+    expect(persisted!.stepSize).toBe(1)
+    expect(persisted!.pinned).toBe(false)
+    expect(persisted!.createdAt).toBeTruthy()
+    expect(persisted!.updatedAt).toBeTruthy()
+  })
+
+  it('increment writes an increment event and updates updatedAt', async () => {
+    const tracker = await createSampleTracker()
+    const before = tracker.updatedAt
+    await useTrakkly.getState().increment(tracker.id)
+
+    const events = await db.events.where('trackerId').equals(tracker.id).toArray()
+    expect(events.length).toBe(1)
+    expect(events[0].type).toBe('increment')
+    expect(events[0].value).toBe(1)
+
+    const updated = await db.trackers.get(tracker.id)
+    expect(updated!.updatedAt >= before).toBe(true)
+  })
+
+  it('adjust writes an adjustment event with delta and reason', async () => {
+    const tracker = await createSampleTracker()
+    await useTrakkly.getState().adjust(tracker.id, -2, 'fix')
+
+    const events = await db.events.where('trackerId').equals(tracker.id).toArray()
+    expect(events.length).toBe(1)
+    expect(events[0].type).toBe('adjustment')
+    expect(events[0].value).toBe(-2)
+    expect(events[0].reason).toBe('fix')
+  })
+
+  it('togglePin toggles pinned state and persists', async () => {
+    const tracker = await createSampleTracker()
+    let persisted = await db.trackers.get(tracker.id)
+    expect(persisted!.pinned).toBe(false)
+
+    await useTrakkly.getState().togglePin(tracker.id)
+    persisted = await db.trackers.get(tracker.id)
+    expect(persisted!.pinned).toBe(true)
+
+    await useTrakkly.getState().togglePin(tracker.id, false)
+    persisted = await db.trackers.get(tracker.id)
+    expect(persisted!.pinned).toBe(false)
+  })
+})

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -12,6 +12,7 @@ export type TrakklyState = {
   increment: (trackerId: string) => Promise<void>
   adjust: (trackerId: string, delta: number, reason?: string) => Promise<void>
   listTrackers: () => Promise<Tracker[]>
+  togglePin: (trackerId: string, pinned?: boolean) => Promise<void>
 }
 
 function nowIso() { return new Date().toISOString() }
@@ -82,6 +83,16 @@ export const useTrakkly = create<TrakklyState>((set, _get) => ({
       deviceId: DEVICE_ID,
     }
     await db.events.add(ev)
+    tracker.updatedAt = nowIso()
+    await db.trackers.put(tracker)
+    const trackers = await db.trackers.toArray()
+    set({ trackers })
+  },
+
+  togglePin: async (trackerId, pinned) => {
+    const tracker = await db.trackers.get(trackerId)
+    if (!tracker) return
+    tracker.pinned = typeof pinned === 'boolean' ? pinned : !tracker.pinned
     tracker.updatedAt = nowIso()
     await db.trackers.put(tracker)
     const trackers = await db.trackers.toArray()

--- a/app/src/test/resetDb.ts
+++ b/app/src/test/resetDb.ts
@@ -1,0 +1,12 @@
+import Dexie from 'dexie'
+import { db } from '../db/db'
+
+export async function resetDb() {
+  try {
+    await db.close()
+    await Dexie.delete('trakkly')
+  } catch {
+    // ignore
+  }
+  await db.open()
+}

--- a/app/src/test/setupTests.ts
+++ b/app/src/test/setupTests.ts
@@ -1,0 +1,9 @@
+import '@testing-library/jest-dom/vitest'
+import 'fake-indexeddb/auto'
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+// Automatically unmount and cleanup DOM after the test is finished.
+afterEach(() => {
+  cleanup()
+})

--- a/app/tsconfig.app.json
+++ b/app/tsconfig.app.json
@@ -21,7 +21,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "types": ["vitest", "node"]
   },
   "include": ["src"]
 }

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['src/test/setupTests.ts'],
+    coverage: {
+      reporter: ['text', 'lcov'],
+      provider: 'v8',
+      reportsDirectory: './coverage',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/**/__tests__/**', 'src/test/**'],
+    },
+    globals: true,
+  },
+})

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -84,8 +84,8 @@
 - Decision:
   - Add CODEOWNERS with maintainers listed (`@jagged3dge`).
   - Protect `main`, `stage`, and `dev` branches:
-    - Require pull request reviews (CODEOWNERS required).
-    - Require status checks to pass (CI job `app-lint-build`).
-    - Restrict who can push (maintainers only) to allow emergency direct pushes by maintainers.
+    - Require pull request reviews (CODEOWNERS required) on `main` and `stage`.
+    - Require status checks to pass (CI job `app-lint-build`) on `main` only.
+    - Dev is relaxed in solo mode: direct pushes allowed for maintainers; PR optional.
   - External contributors open PRs to `dev`; maintainers review/merge and promote via release PRs.
 - Consequences: Prevents accidental direct pushes by non-maintainers; enforces review and CI checks; aligns with CONTRIBUTING policy.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -64,20 +64,23 @@ Derived totals and charts are computed from `Event` log; no destructive edits.
 ## Environments & Releases
 - Environments: dev, staging, prod.
 - Hosting: GitHub Pages (0-cost) for PWA builds.
-- CI/CD: GitHub Actions for lint/test/build; deploy `staging` branch to staging URL, `main` to prod.
+- CI/CD: GitHub Actions
+  - CI (lint/test/build) runs only on PRs targeting `main` (stage → main release PRs).
+  - Deployments: pushes to `stage` and `main` auto-deploy via Pages workflow.
 
 ## Milestones (4 days)
 - Day 1 — Foundations
   - Repo bootstrap (Proprietary license, README). Vite + React + TS + Tailwind + PWA scaffold.
   - Dexie schema for `Tracker`, `Event`, `UserPreferences` + migrations.
-  - Crypto module (Argon2id + AES-GCM) and WebAuthn wrapper; unit tests.
   - UI skeleton: list, add tracker, increment button (writes event).
   - CI and Pages staging deployment.
 - Day 2 — UX & Insights
   - History views, daily/weekly overview, adjustments flow.
+  - Testing: set up Vitest + Testing Library; initial tests for store/utils/components.
   - Pins/tags, filters, basic charts.
   - Preferences and accessibility refinements.
 - Day 3 — Security & PWA polish
+  - Crypto module (Argon2id + AES-GCM) and WebAuthn wrapper; unit tests with vectors and invariants.
   - App lock (device unlock + passcode fallback), auto-lock.
   - Verify at-rest encryption; telemetry toggles; PWA install polish.
 - Day 4 — QA & Release

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,0 +1,68 @@
+# Day 2 Release Notes — UX, Insights, Preferences
+
+## Summary
+This PR promotes Day 2 work into `dev`: user-facing UX improvements, Insights visualizations, Preferences with persistence, and a comprehensive test suite update. CI policy and governance docs were also refined.
+
+## Highlights
+- Pins & Filters (Trackers)
+  - Pin/unpin trackers, sort pinned-first > recent > name
+  - Pinned-only quick filter and tag-based filter
+  - Tracker count in list header
+- Insights
+  - Today card with minimal inline SVG sparkline (hourly bins)
+  - Week overview bar chart (Mon–Sun)
+  - Last 7 days bar chart (sliding window)
+- Preferences
+  - Dexie-backed preferences store
+  - Region: timezone override, locale override
+  - Clock format: 12h / 24h
+  - Accessibility: reduced motion, high contrast
+  - Privacy: Telemetry opt-in (wired to telemetry adapter)
+- Tests
+  - Unit tests for insights utilities
+  - Store tests (increment/adjust/togglePin, prefs load/save, telemetryEnabled)
+  - Component tests for TrackerList (pin toggle + tag filter)
+- CI & Governance
+  - CI runs only on PRs targeting `main`
+  - CODEOWNERS added; CONTRIBUTING updated with branch protections
+
+## Technical Details
+- Data/store
+  - `app/src/state/store.ts`: add `togglePin(trackerId, pinned?)`
+  - `app/src/state/prefs.ts`: preferences store (timezone, locale, clockFormat, a11y, telemetryEnabled)
+- UI
+  - `app/src/components/TrackerList.tsx`: pin/unpin, filters, count, sorting
+  - `app/src/pages/Insights.tsx`: sparkline (Today), weekly bars, last 7 days bars
+  - `app/src/pages/Preferences.tsx`: region, clock, a11y, privacy sections
+  - `app/src/router.tsx`: add `/prefs` route and navigation link
+- Insights utils
+  - `app/src/lib/insights.ts`: eventsForToday/week, totalsByDayInWeek, totalsByLastNDays, sparkline path builder
+- Telemetry wiring
+  - `app/src/providers/AdaptersProvider.tsx`: enable telemetry based on env && prefs.telemetryEnabled
+  - `app/src/config/env.ts`: telemetry keys and default disabled
+- Tests
+  - `app/src/lib/insights.test.ts`, `app/src/state/store.test.ts`, `app/src/state/prefs.test.ts`, `app/src/components/TrackerList.test.tsx`
+
+## How to Test
+- Unit/Component tests
+  - From `app/`: `npm ci && npm run test -- --run` (Vitest)
+- Manual
+  - Trackers: create a few with tags, pin/unpin, use pinned-only and tag filter
+  - Insights: verify Today sparkline, Week overview bars, Last 7 days bars update after increments/adjustments
+  - Preferences: set locale/timezone/clock format and a11y toggles; toggle telemetry opt-in; refresh and verify persistence
+
+## CI / Governance
+- CI will not run for this PR (base is `dev`), by design: Actions trigger only for PRs to `main`.
+- Branch protection: PR + status checks enforced on `main`, PR required (checks optional) on `stage`, relaxed on `dev` for solo mode.
+
+## Backwards Compatibility
+- No breaking changes. Preferences table existed since v1 schema; telemetryEnabled field is optional.
+
+## Release Impact
+- Risk: Low
+- Scope: UX improvements, insights visualizations, prefs, tests
+
+## Next (Day 3)
+- Crypto module: Argon2id KDF + AES-GCM primitives and tests
+- App lock: WebAuthn platform authenticator + passcode fallback, auto-lock
+- Telemetry provider stubs behind feature flags

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -30,6 +30,7 @@ Legend: [ ] pending, [~] in progress, [x] done
 - [x] History list per tracker
 - [~] Daily/weekly overview
 - [x] Adjustment flow (delta + reason)
+- [x] Testing setup: Vitest + Testing Library; initial tests for store/utils/components
 - [ ] Pins/favorites; tag filters
 - [ ] Charts: sparkline + daily bar
 - [ ] Preferences: timezone/locale/12-24h; a11y options

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -31,8 +31,8 @@ Legend: [ ] pending, [~] in progress, [x] done
 - [~] Daily/weekly overview
 - [x] Adjustment flow (delta + reason)
 - [x] Testing setup: Vitest + Testing Library; initial tests for store/utils/components
-- [ ] Pins/favorites; tag filters
-- [ ] Charts: sparkline + daily bar
+- [x] Pins/favorites; tag filters (pin/unpin + pinned-only and tag filter)
+- [~] Charts: sparkline + daily bar (weekly bar + sparkline complete; daily bar pending)
 - [ ] Preferences: timezone/locale/12-24h; a11y options
 
 ## Day 3 — Security & PWA polish

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -32,8 +32,8 @@ Legend: [ ] pending, [~] in progress, [x] done
 - [x] Adjustment flow (delta + reason)
 - [x] Testing setup: Vitest + Testing Library; initial tests for store/utils/components
 - [x] Pins/favorites; tag filters (pin/unpin + pinned-only and tag filter)
-- [~] Charts: sparkline + daily bar (weekly bar + sparkline complete; daily bar pending)
-- [ ] Preferences: timezone/locale/12-24h; a11y options
+- [x] Charts: sparkline + daily bar (weekly bar + sparkline complete; last 7 days bar added)
+- [x] Preferences: timezone/locale/12-24h; a11y options
 
 ## Day 3 — Security & PWA polish
 - [ ] App lock: device unlock (WebAuthn) + passcode fallback; auto-lock

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -24,12 +24,12 @@ Legend: [ ] pending, [~] in progress, [x] done
 - [ ] Crypto module: Argon2id KDF + AES-GCM; WebAuthn key wrapper; unit tests
 - [x] UI skeleton: tracker list, add tracker modal, increment button (persists event)
 - [x] CI: GitHub Actions (lint/test/build)
-- [~] Deploy staging and prod with GitHub Pages (workflow added; enable Pages and promote branches)
+- [x] Deploy staging and prod with GitHub Pages (enabled; stage/main deployed)
 
 ## Day 2 — UX & Insights
-- [ ] History list per tracker
-- [ ] Daily/weekly overview
-- [ ] Adjustment flow (delta + reason)
+- [x] History list per tracker
+- [~] Daily/weekly overview
+- [x] Adjustment flow (delta + reason)
 - [ ] Pins/favorites; tag filters
 - [ ] Charts: sparkline + daily bar
 - [ ] Preferences: timezone/locale/12-24h; a11y options


### PR DESCRIPTION
# Day 2 Release Notes — UX, Insights, Preferences

## Summary
This PR promotes Day 2 work into `dev`: user-facing UX improvements, Insights visualizations, Preferences with persistence, and a comprehensive test suite update. CI policy and governance docs were also refined.

## Highlights
- Pins & Filters (Trackers)
  - Pin/unpin trackers, sort pinned-first > recent > name
  - Pinned-only quick filter and tag-based filter
  - Tracker count in list header
- Insights
  - Today card with minimal inline SVG sparkline (hourly bins)
  - Week overview bar chart (Mon–Sun)
  - Last 7 days bar chart (sliding window)
- Preferences
  - Dexie-backed preferences store
  - Region: timezone override, locale override
  - Clock format: 12h / 24h
  - Accessibility: reduced motion, high contrast
  - Privacy: Telemetry opt-in (wired to telemetry adapter)
- Tests
  - Unit tests for insights utilities
  - Store tests (increment/adjust/togglePin, prefs load/save, telemetryEnabled)
  - Component tests for TrackerList (pin toggle + tag filter)
- CI & Governance
  - CI runs only on PRs targeting `main`
  - CODEOWNERS added; CONTRIBUTING updated with branch protections

## Technical Details
- Data/store
  - `app/src/state/store.ts`: add `togglePin(trackerId, pinned?)`
  - `app/src/state/prefs.ts`: preferences store (timezone, locale, clockFormat, a11y, telemetryEnabled)
- UI
  - `app/src/components/TrackerList.tsx`: pin/unpin, filters, count, sorting
  - `app/src/pages/Insights.tsx`: sparkline (Today), weekly bars, last 7 days bars
  - `app/src/pages/Preferences.tsx`: region, clock, a11y, privacy sections
  - `app/src/router.tsx`: add `/prefs` route and navigation link
- Insights utils
  - `app/src/lib/insights.ts`: eventsForToday/week, totalsByDayInWeek, totalsByLastNDays, sparkline path builder
- Telemetry wiring
  - `app/src/providers/AdaptersProvider.tsx`: enable telemetry based on env && prefs.telemetryEnabled
  - `app/src/config/env.ts`: telemetry keys and default disabled
- Tests
  - `app/src/lib/insights.test.ts`, `app/src/state/store.test.ts`, `app/src/state/prefs.test.ts`, `app/src/components/TrackerList.test.tsx`

## How to Test
- Unit/Component tests
  - From `app/`: `npm ci && npm run test -- --run` (Vitest)
- Manual
  - Trackers: create a few with tags, pin/unpin, use pinned-only and tag filter
  - Insights: verify Today sparkline, Week overview bars, Last 7 days bars update after increments/adjustments
  - Preferences: set locale/timezone/clock format and a11y toggles; toggle telemetry opt-in; refresh and verify persistence

## CI / Governance
- CI will not run for this PR (base is `dev`), by design: Actions trigger only for PRs to `main`.
- Branch protection: PR + status checks enforced on `main`, PR required (checks optional) on `stage`, relaxed on `dev` for solo mode.

## Backwards Compatibility
- No breaking changes. Preferences table existed since v1 schema; telemetryEnabled field is optional.

## Release Impact
- Risk: Low
- Scope: UX improvements, insights visualizations, prefs, tests

## Next (Day 3)
- Crypto module: Argon2id KDF + AES-GCM primitives and tests
- App lock: WebAuthn platform authenticator + passcode fallback, auto-lock
- Telemetry provider stubs behind feature flags
