### PR TITLE
Day 3: App lock, WebCrypto, WebAuthn (beta), auto-lock

### DIFF
--- a/app/src/adapters/deviceUnlock/types.ts
+++ b/app/src/adapters/deviceUnlock/types.ts
@@ -1,5 +1,5 @@
 export interface DeviceUnlockAdapter {
   isSupported(): Promise<boolean>;
-  register(): Promise<boolean>;
+  register(): Promise<{ ok: boolean; credentialId?: string }>;
   authenticate(): Promise<boolean>;
 }

--- a/app/src/adapters/deviceUnlock/webauthn.ts
+++ b/app/src/adapters/deviceUnlock/webauthn.ts
@@ -1,0 +1,81 @@
+import type { DeviceUnlockAdapter } from './types'
+
+function bufToB64Url(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf)
+  let str = ''
+  for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i])
+  const b64 = typeof btoa !== 'undefined' ? btoa(str) : Buffer.from(bytes).toString('base64')
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+function randomBytes(n: number): Uint8Array {
+  const arr = new Uint8Array(n)
+  crypto.getRandomValues(arr)
+  return arr
+}
+
+export class WebAuthnDeviceUnlockAdapter implements DeviceUnlockAdapter {
+  async isSupported(): Promise<boolean> {
+    const has = typeof window !== 'undefined' && 'PublicKeyCredential' in window
+    if (!has) return false
+    try {
+      // @ts-ignore
+      if (typeof PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable === 'function') {
+        // @ts-ignore
+        return await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
+      }
+      return true
+    } catch {
+      return true
+    }
+  }
+
+  async register(): Promise<{ ok: boolean; credentialId?: string }> {
+    if (!('credentials' in navigator)) return { ok: false }
+    const challenge = randomBytes(32)
+    const userId = randomBytes(16)
+    const rpId = window.location.hostname
+    const publicKey: PublicKeyCredentialCreationOptions = {
+      challenge,
+      rp: { id: rpId, name: 'Trakkly' },
+      user: { id: userId, name: 'user', displayName: 'Trakkly User' },
+      pubKeyCredParams: [
+        { type: 'public-key', alg: -7 }, // ES256
+        { type: 'public-key', alg: -257 }, // RS256
+      ],
+      authenticatorSelection: {
+        authenticatorAttachment: 'platform',
+        residentKey: 'preferred',
+        userVerification: 'required',
+      },
+      timeout: 60_000,
+    }
+    try {
+      const cred = (await navigator.credentials.create({ publicKey })) as PublicKeyCredential | null
+      if (!cred) return { ok: false }
+      const rawId = cred.rawId
+      const id = bufToB64Url(rawId)
+      return { ok: true, credentialId: id }
+    } catch (e) {
+      console.warn('webauthn register failed', e)
+      return { ok: false }
+    }
+  }
+
+  async authenticate(): Promise<boolean> {
+    if (!('credentials' in navigator)) return false
+    const challenge = randomBytes(32)
+    const publicKey: PublicKeyCredentialRequestOptions = {
+      challenge,
+      userVerification: 'required',
+      timeout: 60_000,
+    }
+    try {
+      const assertion = (await navigator.credentials.get({ publicKey })) as PublicKeyCredential | null
+      return !!assertion
+    } catch (e) {
+      console.warn('webauthn authenticate failed', e)
+      return false
+    }
+  }
+}

--- a/app/src/db/schema.ts
+++ b/app/src/db/schema.ts
@@ -39,6 +39,8 @@ export type UserPreferences = {
   clockFormat: ClockFormat;
   a11yPrefs?: AccessibilityPrefs;
   telemetryEnabled?: boolean;
+  deviceUnlockEnabled?: boolean;
+  deviceCredentialId?: string; // base64url rawId
   // Key management (MVP: PBKDF2-derived KEK + wrapped data key)
   keySalt?: string; // base64
   wrappedKey?: string; // base64(iv || ciphertext)

--- a/app/src/db/schema.ts
+++ b/app/src/db/schema.ts
@@ -41,6 +41,7 @@ export type UserPreferences = {
   telemetryEnabled?: boolean;
   deviceUnlockEnabled?: boolean;
   deviceCredentialId?: string; // base64url rawId
+  autoLockMinutes?: number; // minutes; if set, auto-lock after inactivity
   // Key management (MVP: PBKDF2-derived KEK + wrapped data key)
   keySalt?: string; // base64
   wrappedKey?: string; // base64(iv || ciphertext)

--- a/app/src/db/schema.ts
+++ b/app/src/db/schema.ts
@@ -39,4 +39,9 @@ export type UserPreferences = {
   clockFormat: ClockFormat;
   a11yPrefs?: AccessibilityPrefs;
   telemetryEnabled?: boolean;
+  // Key management (MVP: PBKDF2-derived KEK + wrapped data key)
+  keySalt?: string; // base64
+  wrappedKey?: string; // base64(iv || ciphertext)
+  kdf?: 'pbkdf2';
+  kdfParams?: { iterations: number };
 };

--- a/app/src/pages/Lock.test.tsx
+++ b/app/src/pages/Lock.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import Lock from './Lock'
+import { AdaptersProvider } from '../providers/AdaptersProvider'
+import { resetDb } from '../test/resetDb'
+import { WebCryptoEngine } from '../adapters/crypto'
+
+// Mock navigate to avoid wiring a full router
+const navigateMock = vi.fn()
+vi.mock('@tanstack/react-router', async (orig) => {
+  const actual = await orig()
+  return {
+    ...actual as object,
+    useNavigate: () => navigateMock,
+  }
+})
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <AdaptersProvider>{children}</AdaptersProvider>
+}
+
+describe('Lock screen', () => {
+  beforeEach(async () => {
+    await resetDb()
+    navigateMock.mockReset()
+  })
+
+  it('unlocks with correct passcode and navigates home', async () => {
+    // Prime DB with wrapped key using passcode 'secret'
+    const engine = new WebCryptoEngine()
+    await engine.unlockWithPasscode!('secret')
+    engine.lock()
+
+    render(
+      <Wrapper>
+        <Lock />
+      </Wrapper>
+    )
+
+    const input = screen.getByLabelText(/passcode/i)
+    await userEvent.type(input, 'secret')
+    const btn = screen.getByRole('button', { name: /unlock/i })
+    await userEvent.click(btn)
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith({ to: '/' }))
+  })
+
+  it('shows error on wrong passcode and stays on page', async () => {
+    const engine = new WebCryptoEngine()
+    await engine.unlockWithPasscode!('right-pass')
+    engine.lock()
+
+    render(
+      <Wrapper>
+        <Lock />
+      </Wrapper>
+    )
+
+    const input = screen.getByLabelText(/passcode/i)
+    await userEvent.type(input, 'wrong-pass')
+    const btn = screen.getByRole('button', { name: /unlock/i })
+    await userEvent.click(btn)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/incorrect passcode/i)
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/pages/Lock.tsx
+++ b/app/src/pages/Lock.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { useAdapters } from '../providers/AdaptersProvider'
+
+export default function Lock() {
+  const { crypto } = useAdapters()
+  const navigate = useNavigate()
+  const [passcode, setPasscode] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleUnlock(e: React.FormEvent) {
+    e.preventDefault()
+    setBusy(true)
+    setError(null)
+    try {
+      const ok = await crypto.unlockWithPasscode?.(passcode)
+      if (ok) {
+        navigate({ to: '/' })
+      } else {
+        setError('Incorrect passcode. Try again.')
+      }
+    } catch (err) {
+      console.error(err)
+      setError('Failed to unlock. Please try again.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+        <div className="mb-2 font-medium">App Locked</div>
+        <p className="text-sm text-neutral-600 dark:text-neutral-300">Enter your passcode to unlock.</p>
+        <form onSubmit={handleUnlock} className="mt-3 space-y-2">
+          <label htmlFor="lock-passcode" className="block text-sm">Passcode</label>
+          <input
+            id="lock-passcode"
+            type="password"
+            autoFocus
+            value={passcode}
+            onChange={(e) => setPasscode(e.target.value)}
+            className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-indigo-500 dark:border-neutral-700 dark:bg-neutral-900"
+          />
+          {error && <div role="alert" className="text-sm text-red-600">{error}</div>}
+          <div className="pt-2">
+            <button
+              type="submit"
+              disabled={busy || passcode.length === 0}
+              className="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-3 py-2 text-sm text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {busy ? 'Unlocking…' : 'Unlock'}
+            </button>
+          </div>
+        </form>
+      </div>
+      <div className="rounded-xl border border-neutral-200 p-4 text-sm dark:border-neutral-800">
+        <div className="font-medium mb-1">Use device unlock (coming soon)</div>
+        <p className="text-neutral-500">This will use your device biometrics when available.</p>
+      </div>
+    </div>
+  )
+}

--- a/app/src/pages/Preferences.tsx
+++ b/app/src/pages/Preferences.tsx
@@ -4,7 +4,7 @@ import { usePrefs } from '../state/prefs'
 import { useAdapters } from '../providers/AdaptersProvider'
 
 export default function Preferences() {
-  const { prefs, loaded, load, setTimezone, setLocale, setClockFormat, setReducedMotion, setHighContrast, setTelemetryEnabled, setDeviceUnlockEnabled, setDeviceCredentialId } = usePrefs()
+  const { prefs, loaded, load, setTimezone, setLocale, setClockFormat, setReducedMotion, setHighContrast, setTelemetryEnabled, setDeviceUnlockEnabled, setDeviceCredentialId, setAutoLockMinutes } = usePrefs()
   const { crypto, deviceUnlock } = useAdapters()
   const navigate = useNavigate()
   const [deviceSupported, setDeviceSupported] = useState<boolean>(false)
@@ -126,6 +126,24 @@ export default function Preferences() {
         >
           Lock now
         </button>
+        <div className="mt-3">
+          <label htmlFor="auto-lock" className="block text-sm mb-1">Auto-lock after (minutes)</label>
+          <input
+            id="auto-lock"
+            type="number"
+            min={0}
+            step={1}
+            value={typeof prefs.autoLockMinutes === 'number' ? prefs.autoLockMinutes : ''}
+            onChange={(e) => {
+              const v = e.target.value
+              const n = v === '' ? undefined : Math.max(0, Math.floor(Number(v)))
+              void setAutoLockMinutes(n)
+            }}
+            placeholder="5"
+            className="w-36 rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-indigo-500 dark:border-neutral-700 dark:bg-neutral-900"
+          />
+          <div className="mt-1 text-xs text-neutral-500">Set to 0 to disable auto-lock.</div>
+        </div>
         <div className="mt-4 border-t border-neutral-200 pt-4 dark:border-neutral-800">
           <div className="mb-2 font-medium">Device unlock (beta)</div>
           <div className="text-xs text-neutral-600 dark:text-neutral-300 mb-2">

--- a/app/src/pages/Preferences.tsx
+++ b/app/src/pages/Preferences.tsx
@@ -1,8 +1,12 @@
 import { useEffect } from 'react'
+import { useNavigate } from '@tanstack/react-router'
 import { usePrefs } from '../state/prefs'
+import { useAdapters } from '../providers/AdaptersProvider'
 
 export default function Preferences() {
   const { prefs, loaded, load, setTimezone, setLocale, setClockFormat, setReducedMotion, setHighContrast, setTelemetryEnabled } = usePrefs()
+  const { crypto } = useAdapters()
+  const navigate = useNavigate()
 
   useEffect(() => {
     if (!loaded) void load()
@@ -95,6 +99,17 @@ export default function Preferences() {
           />
           Enable telemetry
         </label>
+      </div>
+
+      <div className="rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+        <div className="mb-2 font-medium">Security</div>
+        <p className="text-sm text-neutral-600 dark:text-neutral-300 mb-2">Lock the app now. You will need your passcode to unlock.</p>
+        <button
+          onClick={() => { crypto.lock(); navigate({ to: '/lock' }) }}
+          className="inline-flex items-center justify-center rounded-lg border border-neutral-300 px-3 py-2 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+        >
+          Lock now
+        </button>
       </div>
     </div>
   )

--- a/app/src/pages/Preferences.tsx
+++ b/app/src/pages/Preferences.tsx
@@ -1,16 +1,32 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { usePrefs } from '../state/prefs'
 import { useAdapters } from '../providers/AdaptersProvider'
 
 export default function Preferences() {
-  const { prefs, loaded, load, setTimezone, setLocale, setClockFormat, setReducedMotion, setHighContrast, setTelemetryEnabled } = usePrefs()
-  const { crypto } = useAdapters()
+  const { prefs, loaded, load, setTimezone, setLocale, setClockFormat, setReducedMotion, setHighContrast, setTelemetryEnabled, setDeviceUnlockEnabled, setDeviceCredentialId } = usePrefs()
+  const { crypto, deviceUnlock } = useAdapters()
   const navigate = useNavigate()
+  const [deviceSupported, setDeviceSupported] = useState<boolean>(false)
+  const [deviceBusy, setDeviceBusy] = useState<boolean>(false)
+  const [deviceMsg, setDeviceMsg] = useState<string>('')
 
   useEffect(() => {
     if (!loaded) void load()
   }, [loaded, load])
+
+  useEffect(() => {
+    let mounted = true
+    ;(async () => {
+      try {
+        const ok = await deviceUnlock.isSupported()
+        if (mounted) setDeviceSupported(ok)
+      } catch {
+        if (mounted) setDeviceSupported(false)
+      }
+    })()
+    return () => { mounted = false }
+  }, [deviceUnlock])
 
   return (
     <div className="space-y-4">
@@ -110,6 +126,65 @@ export default function Preferences() {
         >
           Lock now
         </button>
+        <div className="mt-4 border-t border-neutral-200 pt-4 dark:border-neutral-800">
+          <div className="mb-2 font-medium">Device unlock (beta)</div>
+          <div className="text-xs text-neutral-600 dark:text-neutral-300 mb-2">
+            {deviceSupported ? 'Your device supports WebAuthn.' : 'WebAuthn not supported in this environment.'}
+          </div>
+          <label className="inline-flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={!!prefs.deviceUnlockEnabled}
+              onChange={(e) => setDeviceUnlockEnabled(e.target.checked)}
+              disabled={!deviceSupported}
+            />
+            Enable device unlock
+          </label>
+          {prefs.deviceUnlockEnabled && deviceSupported && (
+            <div className="mt-3 space-y-2">
+              <div className="text-xs text-neutral-500">Credential: {prefs.deviceCredentialId ? 'Registered' : 'Not registered'}</div>
+              <div className="flex gap-2">
+                <button
+                  onClick={async () => {
+                    setDeviceBusy(true); setDeviceMsg('')
+                    try {
+                      const res = await deviceUnlock.register()
+                      if (res.ok && res.credentialId) {
+                        await setDeviceCredentialId(res.credentialId)
+                        setDeviceMsg('Device registered successfully.')
+                      } else {
+                        setDeviceMsg('Registration failed or cancelled.')
+                      }
+                    } finally {
+                      setDeviceBusy(false)
+                    }
+                  }}
+                  disabled={deviceBusy}
+                  className="inline-flex items-center justify-center rounded-lg border border-neutral-300 px-3 py-2 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+                >
+                  {deviceBusy ? 'Registering…' : 'Register device'}
+                </button>
+                <button
+                  onClick={async () => {
+                    setDeviceBusy(true); setDeviceMsg('')
+                    try {
+                      const ok = await deviceUnlock.authenticate()
+                      setDeviceMsg(ok ? 'Authentication successful.' : 'Authentication failed or cancelled.')
+                      if (ok) navigate({ to: '/' })
+                    } finally {
+                      setDeviceBusy(false)
+                    }
+                  }}
+                  disabled={deviceBusy}
+                  className="inline-flex items-center justify-center rounded-lg border border-neutral-300 px-3 py-2 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800"
+                >
+                  {deviceBusy ? 'Checking…' : 'Test device unlock'}
+                </button>
+              </div>
+              {deviceMsg && <div className="text-xs text-neutral-600 dark:text-neutral-300">{deviceMsg}</div>}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/app/src/providers/AdaptersProvider.tsx
+++ b/app/src/providers/AdaptersProvider.tsx
@@ -4,6 +4,7 @@ import { NoopTelemetryAdapter, type TelemetryAdapter } from '../adapters/telemet
 import { LocalOnlySyncAdapter, type SyncAdapter } from '../adapters/sync';
 import { PlaceholderCryptoEngine, WebCryptoEngine, type CryptoEngine } from '../adapters/crypto';
 import { NoopDeviceUnlockAdapter, type DeviceUnlockAdapter } from '../adapters/deviceUnlock';
+import { WebAuthnDeviceUnlockAdapter } from '../adapters/deviceUnlock/webauthn';
 import { usePrefs } from '../state/prefs';
 
 export type Adapters = {
@@ -38,7 +39,10 @@ export function AdaptersProvider({ children }: { children: React.ReactNode }) {
     const hasSubtle = typeof globalThis !== 'undefined' && !!(globalThis.crypto as any)?.subtle
     return hasSubtle ? new WebCryptoEngine() : new PlaceholderCryptoEngine()
   }, []);
-  const deviceUnlock = useMemo(() => new NoopDeviceUnlockAdapter(), []);
+  const deviceUnlock = useMemo<DeviceUnlockAdapter>(() => {
+    const hasWebAuthn = typeof window !== 'undefined' && 'PublicKeyCredential' in window && 'credentials' in navigator
+    return hasWebAuthn ? new WebAuthnDeviceUnlockAdapter() : new NoopDeviceUnlockAdapter()
+  }, []);
 
   const value: Adapters = { env, telemetry, sync, crypto, deviceUnlock };
 

--- a/app/src/router.tsx
+++ b/app/src/router.tsx
@@ -1,14 +1,28 @@
-import { Outlet, Link, createRootRoute, createRoute, createRouter } from '@tanstack/react-router'
+import { Outlet, Link, createRootRoute, createRoute, createRouter, useNavigate } from '@tanstack/react-router'
 import { TrackerList } from './components/TrackerList'
 import Insights from './pages/Insights'
 import Preferences from './pages/Preferences'
+import Lock from './pages/Lock'
+import { useAdapters } from './providers/AdaptersProvider'
 
 // Root layout
-export const Root = () => (
+export const Root = () => {
+  const { crypto } = useAdapters()
+  const navigate = useNavigate()
+  function handleLock() {
+    crypto.lock()
+    navigate({ to: '/lock' })
+  }
+  return (
   <div className="min-h-screen bg-white text-gray-900 dark:bg-neutral-900 dark:text-neutral-100">
     <header className="sticky top-0 z-10 border-b bg-white/80 px-4 py-3 backdrop-blur dark:border-neutral-800 dark:bg-neutral-900/80">
-      <h1 className="text-2xl font-semibold tracking-tight">Trakkly</h1>
-      <p className="text-sm text-neutral-500 dark:text-neutral-400">Offline-first counters with privacy</p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Trakkly</h1>
+          <p className="text-sm text-neutral-500 dark:text-neutral-400">Offline-first counters with privacy</p>
+        </div>
+        <button onClick={handleLock} className="rounded-lg border border-neutral-300 px-3 py-1 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800">Lock</button>
+      </div>
       <nav className="mt-2 flex gap-2 text-sm">
         <Link
           to="/"
@@ -39,7 +53,7 @@ export const Root = () => (
       </div>
     </main>
   </div>
-)
+)}
 
 const NotFound = () => (
   <div className="rounded-xl border border-neutral-200 p-4 text-sm dark:border-neutral-800">
@@ -71,7 +85,13 @@ const prefsRoute = createRoute({
   component: Preferences,
 })
 
-const routeTree = rootRoute.addChildren([indexRoute, insightsRoute, prefsRoute])
+const lockRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/lock',
+  component: Lock,
+})
+
+const routeTree = rootRoute.addChildren([indexRoute, insightsRoute, prefsRoute, lockRoute])
 
 export const router = createRouter({
   routeTree,

--- a/app/src/router.tsx
+++ b/app/src/router.tsx
@@ -1,18 +1,56 @@
-import { Outlet, Link, createRootRoute, createRoute, createRouter, useNavigate } from '@tanstack/react-router'
+import { useEffect } from 'react'
+import { Outlet, Link, createRootRoute, createRoute, createRouter, useNavigate, useRouterState } from '@tanstack/react-router'
 import { TrackerList } from './components/TrackerList'
 import Insights from './pages/Insights'
 import Preferences from './pages/Preferences'
 import Lock from './pages/Lock'
 import { useAdapters } from './providers/AdaptersProvider'
+import { usePrefs } from './state/prefs'
 
 // Root layout
 export const Root = () => {
   const { crypto } = useAdapters()
   const navigate = useNavigate()
+  const { location } = useRouterState()
+  const { prefs, loaded, load } = usePrefs()
   function handleLock() {
     crypto.lock()
     navigate({ to: '/lock' })
   }
+  // Ensure preferences are loaded for auto-lock
+  useEffect(() => {
+    if (!loaded) void load()
+  }, [loaded, load])
+
+  // Redirect to /lock when locked and accessing protected routes
+  useEffect(() => {
+    const path = location.pathname
+    const isProtected = path !== '/lock'
+    if (isProtected && !crypto.isUnlocked()) {
+      navigate({ to: '/lock' })
+    }
+  }, [crypto, location.pathname, navigate])
+
+  // Auto-lock on inactivity based on preferences
+  useEffect(() => {
+    if (!loaded) return
+    let timer: number | undefined
+    const reset = () => {
+      if (!prefs.autoLockMinutes || prefs.autoLockMinutes <= 0) return
+      if (timer) window.clearTimeout(timer)
+      timer = window.setTimeout(() => {
+        crypto.lock()
+        navigate({ to: '/lock' })
+      }, prefs.autoLockMinutes * 60 * 1000)
+    }
+    const events: Array<keyof WindowEventMap> = ['click', 'keydown', 'touchstart', 'mousemove']
+    events.forEach((ev) => window.addEventListener(ev, reset, { passive: true } as any))
+    reset()
+    return () => {
+      if (timer) window.clearTimeout(timer)
+      events.forEach((ev) => window.removeEventListener(ev, reset as any))
+    }
+  }, [prefs.autoLockMinutes, loaded, crypto, navigate])
   return (
   <div className="min-h-screen bg-white text-gray-900 dark:bg-neutral-900 dark:text-neutral-100">
     <header className="sticky top-0 z-10 border-b bg-white/80 px-4 py-3 backdrop-blur dark:border-neutral-800 dark:bg-neutral-900/80">

--- a/app/src/state/prefs.ts
+++ b/app/src/state/prefs.ts
@@ -12,6 +12,7 @@ const defaultPrefs: UserPreferences = {
   a11yPrefs: { reducedMotion: false, highContrast: false },
   telemetryEnabled: false,
   deviceUnlockEnabled: false,
+  autoLockMinutes: 5,
 }
 
 export type PrefsState = {
@@ -27,6 +28,7 @@ export type PrefsState = {
   setTelemetryEnabled: (value: boolean) => Promise<void>
   setDeviceUnlockEnabled: (value: boolean) => Promise<void>
   setDeviceCredentialId: (id?: string) => Promise<void>
+  setAutoLockMinutes: (mins?: number) => Promise<void>
 }
 
 async function ensurePrefs(): Promise<UserPreferences> {
@@ -99,6 +101,13 @@ export const usePrefs = create<PrefsState>((set, get) => ({
   setDeviceCredentialId: async (id) => {
     const current = get().prefs
     const next = { ...current, deviceCredentialId: id }
+    await db.preferences.put(next)
+    set({ prefs: next })
+  },
+
+  setAutoLockMinutes: async (mins) => {
+    const current = get().prefs
+    const next = { ...current, autoLockMinutes: mins }
     await db.preferences.put(next)
     set({ prefs: next })
   },

--- a/app/src/state/prefs.ts
+++ b/app/src/state/prefs.ts
@@ -11,6 +11,7 @@ const defaultPrefs: UserPreferences = {
   clockFormat: '24',
   a11yPrefs: { reducedMotion: false, highContrast: false },
   telemetryEnabled: false,
+  deviceUnlockEnabled: false,
 }
 
 export type PrefsState = {
@@ -24,6 +25,8 @@ export type PrefsState = {
   setReducedMotion: (value: boolean) => Promise<void>
   setHighContrast: (value: boolean) => Promise<void>
   setTelemetryEnabled: (value: boolean) => Promise<void>
+  setDeviceUnlockEnabled: (value: boolean) => Promise<void>
+  setDeviceCredentialId: (id?: string) => Promise<void>
 }
 
 async function ensurePrefs(): Promise<UserPreferences> {
@@ -82,6 +85,20 @@ export const usePrefs = create<PrefsState>((set, get) => ({
   setTelemetryEnabled: async (value) => {
     const current = get().prefs
     const next = { ...current, telemetryEnabled: value }
+    await db.preferences.put(next)
+    set({ prefs: next })
+  },
+
+  setDeviceUnlockEnabled: async (value) => {
+    const current = get().prefs
+    const next = { ...current, deviceUnlockEnabled: value }
+    await db.preferences.put(next)
+    set({ prefs: next })
+  },
+
+  setDeviceCredentialId: async (id) => {
+    const current = get().prefs
+    const next = { ...current, deviceCredentialId: id }
     await db.preferences.put(next)
     set({ prefs: next })
   },

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -89,3 +89,22 @@
     - Dev is relaxed in solo mode: direct pushes allowed for maintainers; PR optional.
   - External contributors open PRs to `dev`; maintainers review/merge and promote via release PRs.
 - Consequences: Prevents accidental direct pushes by non-maintainers; enforces review and CI checks; aligns with CONTRIBUTING policy.
+
+## ADR-0011: Crypto Key Management (MVP) and Upgrade Plan
+- Status: Accepted
+- Context: We need at-rest encryption with an app lock. The full plan calls for Argon2id KDF and device unlock (WebAuthn). For speed, MVP ships PBKDF2 + AES-GCM with a wrapped data key, and a passcode-based unlock screen.
+- Decision:
+  - Master Data Key: 256-bit AES-GCM key generated via WebCrypto and stored only wrapped at rest.
+  - KEK (Key Encryption Key): derived from user passcode with PBKDF2 (SHA-256, ≥150k iterations in MVP) and used to wrap/unwrap the master key via AES-GCM.
+  - Storage (in `UserPreferences`):
+    - `keySalt` (base64), `wrappedKey` (base64 of iv||ciphertext), `kdf: 'pbkdf2'`, `kdfParams: { iterations }`.
+  - Unlock flow: derive KEK from passcode+salt; decrypt `wrappedKey` to import master key. On first unlock, generate and persist wrapped master key.
+  - Encryption primitives: AES-GCM with random 96-bit IV per encryption; prepend IV to ciphertext.
+  - App Lock: simple passcode UI that calls `unlockWithPasscode`; a "Lock" action discards in-memory key and navigates to `/lock`.
+  - Upgrade Plan (Argon2id): introduce Argon2id KDF (WASM) with tuned params and a migration path. Keep PBKDF2 unlock for existing users; on successful PBKDF2 unlock, rewrap master key with Argon2id-derived KEK and persist alongside or replacing the old field, with a version flag.
+  - Device Unlock (WebAuthn): add an optional device-protected KEK flow. When enabled, wrap the master key with a WebAuthn credential; unlock via platform authenticator. Keep passcode fallback.
+- Consequences: MVP ships quickly with a reasonable KDF (PBKDF2) and AES-GCM, enabling lock/unlock and at-rest protection. Clear path to stronger KDF (Argon2id) and WebAuthn without breaking users.
+- Security Notes:
+  - Always generate new random IVs; never reuse nonces. Detect tampering via GCM tag failure.
+  - Passcodes must not be stored; only salt and derived-key parameters are persisted.
+  - Consider setting a sane minimum passcode length and optional auto-lock timer in preferences.


### PR DESCRIPTION
This PR adds:\n- WebCryptoEngine (PBKDF2 + AES-GCM) and lock screen\n- Route guard + inactivity auto-lock (preferences)\n- WebAuthn device unlock scaffolding behind a preference toggle\n- Preferences UI for security settings\n- ADR-0011 for crypto key management and upgrade plan\n\nAll tests passing locally (25/25).