### PR TITLE
Day 4: PWA polish (install prompt, runtime caching, manifest/theme)

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -2,9 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/icons/icon-192.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <meta name="theme-color" content="#4f46e5" />
+    <title>Trakkly</title>
   </head>
   <body>
     <div id="root"></div>

--- a/app/src/hooks/useInstallPrompt.ts
+++ b/app/src/hooks/useInstallPrompt.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState, useCallback } from 'react'
+
+export function useInstallPrompt() {
+  const [deferred, setDeferred] = useState<any | null>(null)
+  const [installed, setInstalled] = useState(false)
+
+  useEffect(() => {
+    function onBeforeInstallPrompt(e: any) {
+      e.preventDefault()
+      setDeferred(e)
+    }
+    function onAppInstalled() {
+      setInstalled(true)
+      setDeferred(null)
+    }
+    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+    window.addEventListener('appinstalled', onAppInstalled)
+
+    // initial installed detection
+    const standalone = window.matchMedia?.('(display-mode: standalone)').matches || (navigator as any).standalone
+    if (standalone) setInstalled(true)
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+      window.removeEventListener('appinstalled', onAppInstalled)
+    }
+  }, [])
+
+  const canInstall = !!deferred && !installed
+
+  const promptInstall = useCallback(async () => {
+    if (!deferred) return false
+    deferred.prompt()
+    const choice = await deferred.userChoice
+    setDeferred(null)
+    return choice?.outcome === 'accepted'
+  }, [deferred])
+
+  return { canInstall, installed, promptInstall }
+}

--- a/app/src/router.tsx
+++ b/app/src/router.tsx
@@ -6,6 +6,7 @@ import Preferences from './pages/Preferences'
 import Lock from './pages/Lock'
 import { useAdapters } from './providers/AdaptersProvider'
 import { usePrefs } from './state/prefs'
+import { useInstallPrompt } from './hooks/useInstallPrompt'
 
 // Root layout
 export const Root = () => {
@@ -13,6 +14,7 @@ export const Root = () => {
   const navigate = useNavigate()
   const { location } = useRouterState()
   const { prefs, loaded, load } = usePrefs()
+  const { canInstall, promptInstall } = useInstallPrompt()
   function handleLock() {
     crypto.lock()
     navigate({ to: '/lock' })
@@ -59,7 +61,12 @@ export const Root = () => {
           <h1 className="text-2xl font-semibold tracking-tight">Trakkly</h1>
           <p className="text-sm text-neutral-500 dark:text-neutral-400">Offline-first counters with privacy</p>
         </div>
-        <button onClick={handleLock} className="rounded-lg border border-neutral-300 px-3 py-1 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800">Lock</button>
+        <div className="flex items-center gap-2">
+          {canInstall && (
+            <button onClick={() => void promptInstall()} className="rounded-lg border border-neutral-300 px-3 py-1 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800">Install</button>
+          )}
+          <button onClick={handleLock} className="rounded-lg border border-neutral-300 px-3 py-1 text-sm hover:bg-neutral-50 dark:border-neutral-700 dark:hover:bg-neutral-800">Lock</button>
+        </div>
       </div>
       <nav className="mt-2 flex gap-2 text-sm">
         <Link

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -12,6 +12,24 @@ export default defineConfig({
       registerType: 'autoUpdate',
       workbox: {
         navigateFallback: 'index.html',
+        runtimeCaching: [
+          {
+            urlPattern: /^https:\/\/fonts\.gstatic\.com\/.*$/i,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'google-fonts-webfonts',
+              expiration: { maxEntries: 16, maxAgeSeconds: 60 * 60 * 24 * 365 },
+            },
+          },
+          {
+            urlPattern: ({ request }) => request.destination === 'image',
+            handler: 'StaleWhileRevalidate',
+            options: {
+              cacheName: 'images',
+              expiration: { maxEntries: 60, maxAgeSeconds: 60 * 60 * 24 * 30 },
+            },
+          },
+        ],
       },
       manifest: {
         name: 'Trakkly',
@@ -27,11 +45,13 @@ export default defineConfig({
             src: 'icons/icon-192.svg',
             sizes: '192x192',
             type: 'image/svg+xml',
+            purpose: 'any maskable',
           },
           {
             src: 'icons/icon-512.svg',
             sizes: '512x512',
             type: 'image/svg+xml',
+            purpose: 'any maskable',
           },
           // maskable icons can be added later with PNGs for better Android support
         ],


### PR DESCRIPTION
This PR improves PWA installability and offline UX:\n- Install button using beforeinstallprompt/appinstalled hook\n- Workbox runtime caching for Google webfonts and images\n- index.html: theme-color, favicon to app icon, title\n- Manifest: mark icons as maskable (SVG for now)\n\nFollow-up: add maskable PNG icons for Android.\n\nAll tests passing locally (29/29).