### PR TITLE
Hotfix: align icon-512.svg with maskable PNG

### DIFF
--- a/app/public/icons/icon-512.svg
+++ b/app/public/icons/icon-512.svg
@@ -1,12 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
-  <defs>
-    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#4f46e5"/>
-      <stop offset="1" stop-color="#7c3aed"/>
-    </linearGradient>
-  </defs>
-  <rect x="0" y="0" width="512" height="512" rx="64" fill="url(#g)"/>
-  <g fill="#fff" transform="translate(256 256) scale(2)">
-    <path d="M-28 -48h56v16h-20v64h-16v-64h-20z"/>
+  <!-- Background to match PNG: solid indigo with rounded corners -->
+  <rect x="0" y="0" width="512" height="512" rx="64" fill="#4f46e5"/>
+  <!-- Centered Lucide 'bar-chart-2' icon in white, scaled to ~65% -->
+  <g transform="translate(89.6 89.6) scale(13.8666667)" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <line x1="18" y1="20" x2="18" y2="10" />
+    <line x1="12" y1="20" x2="12" y2="4" />
+    <line x1="6" y1="20" x2="6" y2="14" />
   </g>
 </svg>


### PR DESCRIPTION
Replace gradient SVG with solid indigo + centered white Lucide bar-chart-2 to match generated PNG. Then proceeding with Lighthouse pass.