### PR TITLE
Hotfix: PostHog host unused var build error

### DIFF
--- a/app/src/adapters/telemetry/posthog.ts
+++ b/app/src/adapters/telemetry/posthog.ts
@@ -12,6 +12,8 @@ export class PosthogTelemetryAdapter implements TelemetryAdapter {
 
   init(): void {
     // Placeholder: integrate posthog-js here when keys are present
+    // reference host to avoid unused warnings in TS until fully wired
+    void this.host
   }
 
   setEnabled(enabled: boolean): void {


### PR DESCRIPTION
Reference host in init() to satisfy TS and unblock builds. No behavior change.