### PR TITLE
ci: Pages deploy + tagged release workflows

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,9 +2,9 @@ name: Deploy GitHub Pages
 
 on:
   push:
-    branches: [ main, stage ]
+    branches: [ dev, stage, main ]
   pull_request:
-    branches: [ main ]
+    branches: [ dev, main ]
 
 permissions:
   contents: read
@@ -48,7 +48,7 @@ jobs:
           path: app/dist
 
   deploy:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stage' || github.event_name == 'pull_request'
+    if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/stage' || github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
- Pages: build with BASE_PATH and deploy via Actions on dev/stage/main and PRs\n- Release: auto-create GitHub Releases on v*.*.* tags\n\nAfter merge, set Pages source to GitHub Actions in repo settings (if not already).