### PR TITLE
chore(seo): canonical/og:url -> GitHub Pages URL

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -26,10 +26,10 @@
     <meta name="twitter:image" content="/icons/icon-512.png" />
     <!-- SEO additions: canonical URL and robots -->
     <!-- NOTE: Update href/content to your production origin when deploying -->
-    <link rel="canonical" href="/" />
+    <link rel="canonical" href="https://jagged3dge.github.io/trakkly/" />
     <meta name="robots" content="index,follow" />
     <!-- Complement Open Graph with explicit URL -->
-    <meta property="og:url" content="/" />
+    <meta property="og:url" content="https://jagged3dge.github.io/trakkly/" />
     <title>Trakkly</title>
   </head>
   <body>


### PR DESCRIPTION
Set canonical and og:url to https://jagged3dge.github.io/trakkly/ for best SEO and link sharing.