### PR TITLE
chore(seo): absolute OG/Twitter image URLs

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -19,11 +19,11 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Trakkly" />
     <meta property="og:description" content="Offline-first personal counters with privacy." />
-    <meta property="og:image" content="/icons/icon-512.png" />
+    <meta property="og:image" content="https://jagged3dge.github.io/trakkly/icons/icon-512.png" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Trakkly" />
     <meta name="twitter:description" content="Offline-first personal counters with privacy." />
-    <meta name="twitter:image" content="/icons/icon-512.png" />
+    <meta name="twitter:image" content="https://jagged3dge.github.io/trakkly/icons/icon-512.png" />
     <!-- SEO additions: canonical URL and robots -->
     <!-- NOTE: Update href/content to your production origin when deploying -->
     <link rel="canonical" href="https://jagged3dge.github.io/trakkly/" />


### PR DESCRIPTION
Use absolute URLs for og:image and twitter:image to improve link unfurling across platforms.