### PR TITLE
chore(release): 0.1.2 version bump + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.2 — 2025-09-22
+
+- SEO: make `og:image` and `twitter:image` absolute for better link unfurling ([#22](https://github.com/jagged3dge/trakkly/pull/22))
+
 ## v0.1.1 — 2025-09-22
 
 - Release hygiene: bump app version to 0.1.1 and include CHANGELOG in repo so tag points to the correct metadata ([#20](https://github.com/jagged3dge/trakkly/pull/20))

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Bump version before tagging per release process. Includes CHANGELOG entry for v0.1.2 (absolute OG/Twitter images).