### PR TITLE
ci(pages): restrict deploy to push; run build checks on PRs incl. stage

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ dev, stage, main ]
   pull_request:
-    branches: [ dev, main ]
+    branches: [ dev, stage, main ]
 
 permissions:
   contents: read
@@ -48,7 +48,7 @@ jobs:
           path: app/dist
 
   deploy:
-    if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/stage' || github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
+    if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/stage' || github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
- Deploy job only on push to dev/stage/main\n- PRs to dev/stage/main run build + artifact upload; no deploy on PR\nThis resolves failing 'deploy' check on PRs (e.g., dev->stage).